### PR TITLE
feat: implementiere M1 — Datenbank-Schema, Migrations, Seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ Bis zum ersten Go-Live (M11) bleibt das Projekt auf `0.0.0`.
 
 ### Added
 
+- **M1 — Datenbank-Schema & Migrations:** Vollständiges initiales Schema
+  als SQLAlchemy-2.0-Modelle (User, Person, Event, EventParticipant,
+  Application, ApplicationRestraint, RestraintType, ArmPosition,
+  HandPosition, HandOrientation), Alembic-Initialmigration mit PostGIS-
+  Aktivierung, `app_user`-Rolle, `updated_at`-Trigger via
+  `clock_timestamp()`, GIST-Index auf `event.geom`, GIN-Indizes für
+  deutsche Volltextsuche auf `note`, RLS aktiv mit permissiver
+  Default-Policy auf den datenführenden Tabellen (M2 ersetzt mit
+  scharfen Policies).
+- Seed-Skripte für RestraintType-Anker-Modelle und alle Position-
+  Lookups (`uv run python -m app.seeds.run`), idempotent via
+  UNIQUE NULLS NOT DISTINCT + ON CONFLICT DO NOTHING.
+- Test-Infrastruktur mit sync-DB-Fixture (psycopg) und optionalem
+  testcontainers-Fallback; 13/13 Tests grün gegen echtes Postgres+PostGIS.
+- ADR-018 dokumentiert die M1-Implementierungsentscheidungen
+  (UUIDv7 client-seitig via uuid-utils, Trigger statt ORM-onupdate,
+  permissive RLS-Default, Seed-Strategie).
+
 - **M0 — Projekt-Setup:** Lauffähiges Skeleton aus FastAPI-Backend
   (`/api/health`, OpenAPI unter `/api/docs`), Next.js-Frontend (App Router,
   TypeScript strict, Tailwind, vorbereitetes shadcn/ui), Postgres+PostGIS-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Selbst gehostetes, geo-referenziertes Logbuch für Fesselungs-Ereignisse einer geschlossenen Gruppe.**
 
 [![Status](https://img.shields.io/badge/status-mvp--phase--1-yellow)](./docs/fahrplan.md)
-[![Phase](https://img.shields.io/badge/phase-M1--bereit-blue)](./docs/fahrplan.md#phasen-übersicht)
+[![Phase](https://img.shields.io/badge/phase-M2--bereit-blue)](./docs/fahrplan.md#phasen-übersicht)
 [![Version](https://img.shields.io/badge/version-v0.0.0-lightgrey)](./docs/project-context.md#1-kerndaten)
 [![Lizenz](https://img.shields.io/badge/lizenz-offen-red)](./docs/project-context.md#6-constraints-operationalisierbar)
 [![Docs](https://img.shields.io/badge/docs-deutsch-yellow)](./docs/project-context.md)
@@ -129,6 +129,10 @@ cp .env.example .env
 
 # Stack starten (Backend + Frontend + Postgres/PostGIS)
 docker compose -f docker/docker-compose.yml up --build
+
+# Schema migrieren und Kataloge seeden (in separater Shell)
+docker compose -f docker/docker-compose.yml exec backend alembic upgrade head
+docker compose -f docker/docker-compose.yml exec backend python -m app.seeds.run
 ```
 
 Nach dem Start (Ports sind nur an `127.0.0.1` gebunden):
@@ -142,8 +146,15 @@ Nach dem Start (Ports sind nur an `127.0.0.1` gebunden):
 ```bash
 cd backend
 uv sync
+
+# Lokal Postgres+PostGIS auf Port 5432, dann:
+export HCMAP_DATABASE_URL='postgresql+asyncpg://hcmap:hcmap@localhost:5432/hcmap'
+uv run alembic upgrade head
+uv run python -m app.seeds.run
+
 uv run uvicorn app.main:app --reload --port 8000
-uv run pytest
+# Tests gegen einen Test-Postgres:
+HCMAP_TEST_DATABASE_URL='postgresql+psycopg://...' uv run pytest
 uv run ruff check .
 uv run mypy app
 ```

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,54 @@
+; Alembic configuration. The DSN comes from the HCMAP_DATABASE_URL env var
+; (read in migrations/env.py); the placeholder below is only used by the
+; CLI when env.py cannot be loaded.
+
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+path_separator = os
+sqlalchemy.url = postgresql+psycopg://hcmap:hcmap@db:5432/hcmap
+file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d_%%(slug)s
+timezone = UTC
+
+[post_write_hooks]
+hooks = ruff, ruff_format
+ruff.type = console_scripts
+ruff.entrypoint = ruff
+ruff.options = check --fix --select I,F401 REVISION_SCRIPT_FILENAME
+ruff_format.type = console_scripts
+ruff_format.entrypoint = ruff
+ruff_format.options = format REVISION_SCRIPT_FILENAME
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,58 @@
+"""Async SQLAlchemy engine, session factory, and FastAPI dependency.
+
+The engine is created lazily so tests can override the database URL via
+the ``HCMAP_DATABASE_URL`` environment variable before first use. Sessions
+are scoped per request; commit/rollback is the caller's responsibility
+(no implicit commit on context exit).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from functools import lru_cache
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.config import get_settings
+
+
+@lru_cache(maxsize=1)
+def get_engine() -> AsyncEngine:
+    """Return the process-wide async engine, creating it on first call."""
+    settings = get_settings()
+    return create_async_engine(
+        settings.database_url,
+        pool_pre_ping=True,
+        future=True,
+    )
+
+
+@lru_cache(maxsize=1)
+def get_sessionmaker() -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(
+        bind=get_engine(),
+        expire_on_commit=False,
+        autoflush=False,
+    )
+
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    """FastAPI dependency yielding an ``AsyncSession``.
+
+    The session is closed on context exit. Errors are NOT swallowed; the
+    caller is expected to commit or rollback explicitly.
+    """
+    sm = get_sessionmaker()
+    async with sm() as session:
+        yield session
+
+
+def reset_engine_cache() -> None:
+    """Clear cached engine/sessionmaker (test helper)."""
+    get_engine.cache_clear()
+    get_sessionmaker.cache_clear()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,41 @@
+"""SQLAlchemy ORM models for HC-Map.
+
+Importing this package registers all mapped classes with the shared
+``Base.metadata`` so Alembic autogenerate sees them.
+"""
+
+from __future__ import annotations
+
+from app.models.application import Application, ApplicationRestraint
+from app.models.base import Base
+from app.models.catalog import (
+    ArmPosition,
+    CatalogStatus,
+    HandOrientation,
+    HandPosition,
+    RestraintCategory,
+    RestraintMechanicalType,
+    RestraintType,
+)
+from app.models.event import Event, EventParticipant
+from app.models.person import Person, PersonOrigin
+from app.models.user import User, UserRole
+
+__all__ = [
+    "Application",
+    "ApplicationRestraint",
+    "ArmPosition",
+    "Base",
+    "CatalogStatus",
+    "Event",
+    "EventParticipant",
+    "HandOrientation",
+    "HandPosition",
+    "Person",
+    "PersonOrigin",
+    "RestraintCategory",
+    "RestraintMechanicalType",
+    "RestraintType",
+    "User",
+    "UserRole",
+]

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -1,0 +1,107 @@
+"""Application and ApplicationRestraint models.
+
+An Application is a single restraint action inside an Event with a Performer
+and Recipient. Multiple applications are sequenced via ``sequence_no``.
+``performer_id != recipient_id`` is a business rule (not a DB constraint),
+deliberately allowing self-bondage cases (architecture.md §Datenmodell).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    PrimaryKeyConstraint,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, CreatedByMixin, TimestampMixin, pk_column
+
+
+class Application(Base, TimestampMixin, CreatedByMixin):
+    __tablename__ = "application"
+    __table_args__ = (
+        UniqueConstraint("event_id", "sequence_no", name="uq_application_event_sequence"),
+        Index("ix_application_event_id", "event_id"),
+        Index("ix_application_performer_id", "performer_id"),
+        Index("ix_application_recipient_id", "recipient_id"),
+        Index("ix_application_event_id_sequence_no", "event_id", "sequence_no"),
+        Index(
+            "ix_application_note_fts",
+            func.to_tsvector("german", "note"),
+            postgresql_using="gin",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = pk_column()
+    event_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("event.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    performer_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    recipient_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    arm_position_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("arm_position.id", ondelete="RESTRICT"),
+        nullable=True,
+    )
+    hand_position_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("hand_position.id", ondelete="RESTRICT"),
+        nullable=True,
+    )
+    hand_orientation_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("hand_orientation.id", ondelete="RESTRICT"),
+        nullable=True,
+    )
+    sequence_no: Mapped[int] = mapped_column(Integer, nullable=False)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class ApplicationRestraint(Base):
+    """n:m link between applications and restraint types."""
+
+    __tablename__ = "application_restraint"
+    __table_args__ = (
+        PrimaryKeyConstraint(
+            "application_id", "restraint_type_id", name="pk_application_restraint"
+        ),
+        Index("ix_application_restraint_restraint_type_id", "restraint_type_id"),
+    )
+
+    application_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("application.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    restraint_type_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("restraint_type.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -1,0 +1,83 @@
+"""SQLAlchemy declarative base, shared mixins, and column helpers.
+
+UUIDv7 primary keys are generated client-side via ``uuid_utils.uuid7()``
+(see ADR-018). Soft-delete fields live on User and Person only; other
+entities are deleted hard.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import uuid_utils
+from sqlalchemy import DateTime, ForeignKey, MetaData, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+# Naming convention keeps Alembic autogenerate diffs stable across machines.
+NAMING_CONVENTION = {
+    "ix": "ix_%(table_name)s_%(column_0_N_name)s",
+    "uq": "uq_%(table_name)s_%(column_0_N_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+
+class Base(DeclarativeBase):
+    """Declarative base with deterministic constraint naming."""
+
+    metadata = MetaData(naming_convention=NAMING_CONVENTION)
+
+
+def uuid7() -> uuid.UUID:
+    """Return a new UUIDv7 as a stdlib ``uuid.UUID``."""
+    return uuid.UUID(str(uuid_utils.uuid7()))
+
+
+def pk_column() -> Mapped[uuid.UUID]:
+    """Standard UUIDv7 primary-key column."""
+    return mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid7)
+
+
+class TimestampMixin:
+    """``created_at`` (DEFAULT now()) and ``updated_at`` (set by trigger).
+
+    The ``updated_at`` trigger is created in the initial Alembic migration
+    (see ADR-018, decision C1).
+    """
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+
+class CreatedByMixin:
+    """``created_by`` FK to ``user.id`` for audit trails."""
+
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+
+class SoftDeleteMixin:
+    """Reserved for User and Person only (anonymisation per ADR-002)."""
+
+    is_deleted: Mapped[bool] = mapped_column(
+        nullable=False,
+        default=False,
+        server_default="false",
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )

--- a/backend/app/models/catalog.py
+++ b/backend/app/models/catalog.py
@@ -1,0 +1,173 @@
+"""Catalog models with proposal workflow.
+
+RestraintType, ArmPosition, HandPosition, HandOrientation share the
+``status`` and ``suggested_by`` / ``approved_by`` proposal flow described
+in fahrplan.md M7. Visibility rules (admin sees all, editors see approved
++ own pending, viewers see approved) are enforced via RLS policies set up
+in M2.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+
+from sqlalchemy import (
+    Enum,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, pk_column
+
+
+class CatalogStatus(str, enum.Enum):
+    """Workflow state shared by all catalog tables."""
+
+    APPROVED = "approved"
+    PENDING = "pending"
+
+
+class RestraintCategory(str, enum.Enum):
+    """High-level grouping for the restraint catalog."""
+
+    HANDCUFFS = "handcuffs"
+    THUMBCUFFS = "thumbcuffs"
+    LEGCUFFS = "legcuffs"
+    CUFFS_LEATHER = "cuffs_leather"
+    ROPE = "rope"
+    TAPE = "tape"
+    CABLE_TIE = "cable_tie"
+    CLOTH = "cloth"
+    STRAP = "strap"
+    OTHER = "other"
+
+
+class RestraintMechanicalType(str, enum.Enum):
+    """Mechanical type for cuff-style restraints."""
+
+    CHAIN = "chain"
+    HINGED = "hinged"
+    RIGID = "rigid"
+
+
+def _enum(enum_cls: type[enum.Enum], pg_name: str) -> Enum:
+    """Postgres enum that stores the enum *value* (lowercase string)."""
+    return Enum(
+        enum_cls,
+        name=pg_name,
+        values_callable=lambda e: [m.value for m in e],
+    )
+
+
+# Shared Postgres enum: catalog_status is reused across four tables. Without
+# inherit_schema=True / create_type=False elsewhere, SQLAlchemy would try to
+# CREATE TYPE multiple times. We define it once here on the metadata and
+# reference the same instance in every column.
+_CATALOG_STATUS = Enum(
+    CatalogStatus,
+    name="catalog_status",
+    values_callable=lambda e: [m.value for m in e],
+    metadata=Base.metadata,
+    create_constraint=True,
+)
+
+
+class RestraintType(Base, TimestampMixin):
+    __tablename__ = "restraint_type"
+    __table_args__ = (
+        UniqueConstraint(
+            "category",
+            "brand",
+            "model",
+            "mechanical_type",
+            name="uq_restraint_type_identity",
+            postgresql_nulls_not_distinct=True,
+        ),
+        Index("ix_restraint_type_status", "status"),
+        Index("ix_restraint_type_category", "category"),
+        Index("ix_restraint_type_brand", "brand"),
+    )
+
+    id: Mapped[uuid.UUID] = pk_column()
+    category: Mapped[RestraintCategory] = mapped_column(
+        _enum(RestraintCategory, "restraint_category"),
+        nullable=False,
+    )
+    brand: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    model: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    mechanical_type: Mapped[RestraintMechanicalType | None] = mapped_column(
+        _enum(RestraintMechanicalType, "restraint_mechanical_type"),
+        nullable=True,
+    )
+    display_name: Mapped[str] = mapped_column(String(300), nullable=False)
+    status: Mapped[CatalogStatus] = mapped_column(
+        _CATALOG_STATUS,
+        nullable=False,
+        default=CatalogStatus.PENDING,
+        server_default=CatalogStatus.PENDING.value,
+    )
+    suggested_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    approved_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class _LookupBase(TimestampMixin):
+    """Shared columns for ArmPosition / HandPosition / HandOrientation."""
+
+    id: Mapped[uuid.UUID] = pk_column()
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[CatalogStatus] = mapped_column(
+        _CATALOG_STATUS,
+        nullable=False,
+        default=CatalogStatus.PENDING,
+        server_default=CatalogStatus.PENDING.value,
+    )
+    suggested_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    approved_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+
+class ArmPosition(Base, _LookupBase):
+    __tablename__ = "arm_position"
+    __table_args__ = (
+        UniqueConstraint("name", name="uq_arm_position_name"),
+        Index("ix_arm_position_status", "status"),
+    )
+
+
+class HandPosition(Base, _LookupBase):
+    __tablename__ = "hand_position"
+    __table_args__ = (
+        UniqueConstraint("name", name="uq_hand_position_name"),
+        Index("ix_hand_position_status", "status"),
+    )
+
+
+class HandOrientation(Base, _LookupBase):
+    __tablename__ = "hand_orientation"
+    __table_args__ = (
+        UniqueConstraint("name", name="uq_hand_orientation_name"),
+        Index("ix_hand_orientation_status", "status"),
+    )

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -1,0 +1,92 @@
+"""Event and EventParticipant models.
+
+An Event is a single geo-located occurrence with one or more Applications
+inside it. Coordinates are stored as decimal lat/lon and as a PostGIS
+``geography(Point, 4326)`` generated column for spatial queries.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from geoalchemy2 import Geography
+from sqlalchemy import (
+    CheckConstraint,
+    Computed,
+    DateTime,
+    ForeignKey,
+    Index,
+    Numeric,
+    PrimaryKeyConstraint,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, CreatedByMixin, TimestampMixin, pk_column
+
+
+class Event(Base, TimestampMixin, CreatedByMixin):
+    __tablename__ = "event"
+    __table_args__ = (
+        CheckConstraint("lat >= -90 AND lat <= 90", name="lat_range"),
+        CheckConstraint("lon >= -180 AND lon <= 180", name="lon_range"),
+        Index("ix_event_started_at", "started_at"),
+        Index("ix_event_ended_at", "ended_at"),
+        Index("ix_event_created_by", "created_by"),
+        Index("ix_event_geom", "geom", postgresql_using="gist"),
+        Index(
+            "ix_event_note_fts",
+            func.to_tsvector("german", "note"),
+            postgresql_using="gin",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = pk_column()
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    lat: Mapped[Decimal] = mapped_column(Numeric(9, 6), nullable=False)
+    lon: Mapped[Decimal] = mapped_column(Numeric(9, 6), nullable=False)
+    geom: Mapped[object] = mapped_column(
+        Geography(geometry_type="POINT", srid=4326),
+        Computed("ST_SetSRID(ST_MakePoint(lon, lat), 4326)::geography", persisted=True),
+        nullable=False,
+    )
+    w3w_legacy: Mapped[str | None] = mapped_column(Text, nullable=True)
+    reveal_participants: Mapped[bool] = mapped_column(
+        nullable=False, default=False, server_default="false"
+    )
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class EventParticipant(Base):
+    """n:m link between events and persons.
+
+    Composite PK (event_id, person_id) prevents duplicates. Auto-Participant
+    rule (ADR-012) is enforced in the service layer (M3+).
+    """
+
+    __tablename__ = "event_participant"
+    __table_args__ = (
+        PrimaryKeyConstraint("event_id", "person_id", name="pk_event_participant"),
+        Index("ix_event_participant_person_id", "person_id"),
+    )
+
+    event_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("event.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    person_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/backend/app/models/person.py
+++ b/backend/app/models/person.py
@@ -1,0 +1,63 @@
+"""Person model.
+
+Persons exist independently of Users (only some persons have a User
+account). On-the-fly persons created from the live capture flow carry
+``origin = on_the_fly`` (see ADR-014). Anonymisation is in-place per
+ADR-002: name replaced, FKs preserved.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+
+from sqlalchemy import Enum, ForeignKey, Index, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import (
+    Base,
+    CreatedByMixin,
+    SoftDeleteMixin,
+    TimestampMixin,
+    pk_column,
+)
+
+
+class PersonOrigin(str, enum.Enum):
+    """How the person record came into existence."""
+
+    MANAGED = "managed"
+    ON_THE_FLY = "on_the_fly"
+
+
+class Person(Base, TimestampMixin, CreatedByMixin, SoftDeleteMixin):
+    __tablename__ = "person"
+    __table_args__ = (
+        Index("ix_person_name", "name"),
+        Index("ix_person_origin", "origin"),
+        Index("ix_person_linkable", "linkable"),
+        Index("ix_person_is_deleted", "is_deleted"),
+    )
+
+    id: Mapped[uuid.UUID] = pk_column()
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    alias: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    origin: Mapped[PersonOrigin] = mapped_column(
+        Enum(PersonOrigin, name="person_origin", values_callable=lambda e: [m.value for m in e]),
+        nullable=False,
+        default=PersonOrigin.MANAGED,
+        server_default=PersonOrigin.MANAGED.value,
+    )
+    linkable: Mapped[bool] = mapped_column(nullable=False, default=False, server_default="false")
+
+    # Override CreatedByMixin to allow person creation before any user exists
+    # (admin-bootstrap, w3w migration). FK is still enforced when set.
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "user.id", ondelete="SET NULL", use_alter=True, name="fk_person_created_by_user"
+        ),
+        nullable=True,
+    )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,53 @@
+"""User model.
+
+Layout follows the fastapi-users SQLAlchemy adapter so M2 can plug it in
+without schema changes. The mandatory 1:1 link to Person is enforced at
+the database level (NOT NULL UNIQUE) per ADR-010.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+
+from sqlalchemy import Enum, ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, SoftDeleteMixin, TimestampMixin, pk_column
+
+
+class UserRole(str, enum.Enum):
+    """Application-level RBAC roles (architecture.md §RLS)."""
+
+    ADMIN = "admin"
+    EDITOR = "editor"
+    VIEWER = "viewer"
+
+
+class User(Base, TimestampMixin, SoftDeleteMixin):
+    __tablename__ = "user"
+    __table_args__ = (
+        UniqueConstraint("email", name="uq_user_email"),
+        UniqueConstraint("person_id", name="uq_user_person_id"),
+        Index("ix_user_role", "role"),
+    )
+
+    id: Mapped[uuid.UUID] = pk_column()
+    email: Mapped[str] = mapped_column(String(320), nullable=False)
+    hashed_password: Mapped[str] = mapped_column(String(1024), nullable=False)
+    is_active: Mapped[bool] = mapped_column(nullable=False, default=True, server_default="true")
+    is_verified: Mapped[bool] = mapped_column(nullable=False, default=False, server_default="false")
+    is_superuser: Mapped[bool] = mapped_column(
+        nullable=False, default=False, server_default="false"
+    )
+    role: Mapped[UserRole] = mapped_column(
+        Enum(UserRole, name="user_role", values_callable=lambda e: [m.value for m in e]),
+        nullable=False,
+    )
+    person_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    display_name: Mapped[str | None] = mapped_column(String(200), nullable=True)

--- a/backend/app/seeds/__init__.py
+++ b/backend/app/seeds/__init__.py
@@ -1,0 +1,6 @@
+"""Catalog seed scripts (M1).
+
+Runs idempotently via INSERT ... ON CONFLICT DO NOTHING on the catalog
+unique constraints. Architecture forbids seed data inside Alembic
+migrations (see ADR-018, decision E1).
+"""

--- a/backend/app/seeds/positions.py
+++ b/backend/app/seeds/positions.py
@@ -1,0 +1,43 @@
+"""Position lookup seeds (M1).
+
+Source: ``architecture.md`` §Katalog-Seed (M1). All entries are seeded with
+``status = 'approved'``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+ARM_POSITIONS: Sequence[str] = (
+    "hinter dem Rücken",
+    "vor dem Körper",
+    "über dem Kopf",
+    "hinter dem Kopf",
+    "seitlich",
+    "gespreizt",
+    "am Körper anliegend",
+    "Strappado",
+)
+
+HAND_POSITIONS: Sequence[str] = (
+    "Handgelenke",
+    "Daumen",
+    "Unterarme",
+    "Handgelenk-an-Ellbogen",
+)
+
+HAND_ORIENTATIONS: Sequence[str] = (
+    "Handrücken zueinander",
+    "Handflächen zueinander",
+    "parallel",
+    "überkreuzt",
+    "Daumen-zu-Daumen",
+)
+
+
+def insert_sql(table: str) -> str:
+    return (
+        f"INSERT INTO {table} (id, name, status) "
+        "VALUES (:id, :name, 'approved') "
+        f"ON CONFLICT ON CONSTRAINT uq_{table}_name DO NOTHING"
+    )

--- a/backend/app/seeds/restraint_types.py
+++ b/backend/app/seeds/restraint_types.py
@@ -1,0 +1,113 @@
+"""RestraintType seed data (M1).
+
+Source: ``architecture.md`` §Katalog-Seed (M1) and ``fahrplan.md`` Z. 105.
+Limited to anchor models that the Admin pre-approved. The wider review list
+in ``docs/restraint-types-seed-review.md`` is loaded after Admin sign-off
+(see ADR-018, decision F1).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RestraintTypeSeed:
+    category: str
+    brand: str | None
+    model: str | None
+    mechanical_type: str | None
+    display_name: str
+    note: str | None = None
+
+
+def _cuff(brand: str, model: str, mech: str) -> RestraintTypeSeed:
+    return RestraintTypeSeed(
+        category="handcuffs",
+        brand=brand,
+        model=model,
+        mechanical_type=mech,
+        display_name=f"{brand} {model} ({mech})",
+    )
+
+
+SEEDS: Sequence[RestraintTypeSeed] = (
+    # Handcuffs — chain
+    _cuff("ASP", "Chain", "chain"),
+    _cuff("Smith & Wesson", "Model 100", "chain"),
+    _cuff("Peerless", "Model 700", "chain"),
+    # Handcuffs — hinged
+    _cuff("ASP", "Ultra Cuffs", "hinged"),
+    _cuff("TCH", "840", "hinged"),
+    _cuff("Peerless", "Model 730", "hinged"),
+    # Handcuffs — rigid
+    _cuff("Clejuso", "Model 13", "rigid"),
+    _cuff("Clejuso", "Model 15 Heavy", "rigid"),
+    _cuff("ASP", "Rigid Ultra", "rigid"),
+    # Thumbcuffs
+    RestraintTypeSeed(
+        category="thumbcuffs",
+        brand="Clejuso",
+        model="Standard",
+        mechanical_type=None,
+        display_name="Clejuso Daumenschellen",
+    ),
+    # Legcuffs
+    RestraintTypeSeed(
+        category="legcuffs",
+        brand="Peerless",
+        model="Model 703",
+        mechanical_type="chain",
+        display_name="Peerless Model 703 Beinschellen",
+    ),
+    # Materials — brand stays NULL, model carries the discriminator so the
+    # UNIQUE(category, brand, model, mechanical_type) NULLS NOT DISTINCT
+    # constraint sees distinct rows.
+    RestraintTypeSeed(
+        category="rope", brand=None, model="Seil", mechanical_type=None, display_name="Seil"
+    ),
+    RestraintTypeSeed(
+        category="tape",
+        brand=None,
+        model="Bondage-Tape",
+        mechanical_type=None,
+        display_name="Bondage-Tape",
+    ),
+    RestraintTypeSeed(
+        category="tape",
+        brand=None,
+        model="Klebeband",
+        mechanical_type=None,
+        display_name="Klebeband",
+    ),
+    RestraintTypeSeed(
+        category="cloth",
+        brand=None,
+        model="Schal",
+        mechanical_type=None,
+        display_name="Schal",
+    ),
+    RestraintTypeSeed(
+        category="strap",
+        brand=None,
+        model="Lederriemen",
+        mechanical_type=None,
+        display_name="Lederriemen",
+    ),
+    RestraintTypeSeed(
+        category="cable_tie",
+        brand=None,
+        model="Kabelbinder",
+        mechanical_type=None,
+        display_name="Kabelbinder",
+    ),
+)
+
+INSERT_SQL = """
+INSERT INTO restraint_type
+    (id, category, brand, model, mechanical_type, display_name, status)
+VALUES
+    (gen_random_uuid(), :category, :brand, :model, :mechanical_type, :display_name, 'approved')
+ON CONFLICT ON CONSTRAINT uq_restraint_type_identity DO NOTHING
+"""

--- a/backend/app/seeds/run.py
+++ b/backend/app/seeds/run.py
@@ -1,0 +1,75 @@
+"""CLI entry point for catalog seeding.
+
+Usage:
+    uv run python -m app.seeds.run
+
+Idempotent: re-running adds nothing if the catalog already contains the
+seed entries (UNIQUE-constraint conflicts are ignored).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy import text
+
+from app.db import get_engine
+from app.models.base import uuid7
+from app.seeds.positions import (
+    ARM_POSITIONS,
+    HAND_ORIENTATIONS,
+    HAND_POSITIONS,
+    insert_sql,
+)
+from app.seeds.restraint_types import INSERT_SQL as RESTRAINT_TYPE_SQL
+from app.seeds.restraint_types import SEEDS as RESTRAINT_TYPE_SEEDS
+
+
+async def seed_lookup(conn: object, table: str, names: tuple[str, ...]) -> int:
+    """Seed one of the position lookup tables, return rows inserted."""
+    stmt = text(insert_sql(table))
+    inserted = 0
+    for name in names:
+        result = await conn.execute(stmt, {"id": uuid7(), "name": name})  # type: ignore[attr-defined]
+        inserted += result.rowcount or 0
+    return inserted
+
+
+async def seed_restraint_types(conn: object) -> int:
+    """Seed the restraint_type catalog with the M1 anchor models."""
+    # Use an explicit id so we can keep UUIDv7 even though the SQL uses a
+    # named parameter. We bind id per row.
+    stmt = text(RESTRAINT_TYPE_SQL.replace("gen_random_uuid()", ":id"))
+    inserted = 0
+    for seed in RESTRAINT_TYPE_SEEDS:
+        result = await conn.execute(  # type: ignore[attr-defined]
+            stmt,
+            {
+                "id": uuid7(),
+                "category": seed.category,
+                "brand": seed.brand,
+                "model": seed.model,
+                "mechanical_type": seed.mechanical_type,
+                "display_name": seed.display_name,
+            },
+        )
+        inserted += result.rowcount or 0
+    return inserted
+
+
+async def main() -> None:
+    engine = get_engine()
+    async with engine.begin() as conn:
+        rt = await seed_restraint_types(conn)
+        ap = await seed_lookup(conn, "arm_position", tuple(ARM_POSITIONS))
+        hp = await seed_lookup(conn, "hand_position", tuple(HAND_POSITIONS))
+        ho = await seed_lookup(conn, "hand_orientation", tuple(HAND_ORIENTATIONS))
+    await engine.dispose()
+    print(
+        f"Seeded: restraint_type={rt}, arm_position={ap}, "
+        f"hand_position={hp}, hand_orientation={ho}"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,107 @@
+"""Alembic environment supporting sync (psycopg) and async (asyncpg) DSNs.
+
+The DSN comes from ``HCMAP_DATABASE_URL`` so dev/test/prod stay aligned
+with the runtime app config. Async DSNs use ``async_engine_from_config``;
+sync DSNs use the regular ``engine_from_config`` so callers (e.g. pytest
+fixtures) can run migrations from inside a running event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from logging.config import fileConfig
+
+from alembic import context
+from app.config import get_settings
+from app.models import Base
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Use the DSN already set in the Alembic config (caller may have overridden
+# it, e.g. test fixtures running migrations on a sync URL). Fall back to
+# runtime settings only when the config still holds the placeholder default.
+_placeholder = "postgresql+psycopg://hcmap:hcmap@db:5432/hcmap"
+if config.get_main_option("sqlalchemy.url") in (None, _placeholder):
+    settings = get_settings()
+    config.set_main_option("sqlalchemy.url", settings.database_url)
+
+target_metadata = Base.metadata
+
+
+def _include_object(
+    object_: object,
+    name: str | None,
+    type_: str,
+    reflected: bool,
+    compare_to: object | None,
+) -> bool:
+    """Skip PostGIS-managed tables/indexes from autogenerate diffs."""
+    if type_ == "table" and name in {"spatial_ref_sys"}:
+        return False
+    return not (type_ == "index" and name and name.startswith("idx_"))
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        include_object=_include_object,
+        compare_type=True,
+        compare_server_default=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        include_object=_include_object,
+        compare_type=True,
+        compare_server_default=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online_async() -> None:
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+def run_migrations_online_sync() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        do_run_migrations(connection)
+    connectable.dispose()
+
+
+def _is_async_url(url: str) -> bool:
+    return "+asyncpg" in url or "+aiomysql" in url or "+aiosqlite" in url
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+elif _is_async_url(config.get_main_option("sqlalchemy.url") or ""):
+    asyncio.run(run_migrations_online_async())
+else:
+    run_migrations_online_sync()

--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,27 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision: str = ${repr(up_revision)}
+down_revision: str | None = ${repr(down_revision)}
+branch_labels: str | Sequence[str] | None = ${repr(branch_labels)}
+depends_on: str | Sequence[str] | None = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/migrations/versions/20260425_1700_initial_schema.py
+++ b/backend/migrations/versions/20260425_1700_initial_schema.py
@@ -1,0 +1,572 @@
+"""Initial HC-Map schema (M1).
+
+Creates the PostGIS extension, the ``app_user`` role, all 10 base tables,
+their indices, an ``updated_at`` trigger, and a permissive RLS default
+policy on the data-bearing tables (per ADR-018, decision D1). The strict
+per-role RLS policies from ``architecture.md`` §RLS are applied in M2.
+
+Revision ID: 20260425_1700_initial
+Revises:
+Create Date: 2026-04-25 17:00:00 UTC
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from geoalchemy2 import Geography
+
+revision: str = "20260425_1700_initial"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Tables that carry RLS in M1 (data-bearing). Catalog tables get strict
+# per-role policies in M2 alongside fastapi-users.
+_RLS_TABLES = (
+    "event",
+    "event_participant",
+    "application",
+    "application_restraint",
+)
+
+# Tables that get the updated_at trigger.
+_UPDATED_AT_TABLES = (
+    "user",
+    "person",
+    "event",
+    "application",
+    "restraint_type",
+    "arm_position",
+    "hand_position",
+    "hand_orientation",
+)
+
+
+def upgrade() -> None:
+    # -- Extensions ---------------------------------------------------------
+    op.execute("CREATE EXTENSION IF NOT EXISTS postgis")
+
+    # -- Application role (NOLOGIN; backend SET ROLEs to it per session) ----
+    # IF NOT EXISTS is not part of CREATE ROLE; do a guarded DO block.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user') THEN
+                CREATE ROLE app_user NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+    # -- updated_at trigger function (one shared function) -----------------
+    # clock_timestamp() returns wall-clock time so multi-statement
+    # transactions still see distinct created_at vs updated_at.
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION set_updated_at() RETURNS trigger
+        LANGUAGE plpgsql AS $$
+        BEGIN
+            NEW.updated_at = clock_timestamp();
+            RETURN NEW;
+        END;
+        $$;
+        """
+    )
+
+    # -- Enums --------------------------------------------------------------
+    user_role = sa.Enum("admin", "editor", "viewer", name="user_role")
+    person_origin = sa.Enum("managed", "on_the_fly", name="person_origin")
+    catalog_status = sa.Enum("approved", "pending", name="catalog_status")
+    restraint_category = sa.Enum(
+        "handcuffs",
+        "thumbcuffs",
+        "legcuffs",
+        "cuffs_leather",
+        "rope",
+        "tape",
+        "cable_tie",
+        "cloth",
+        "strap",
+        "other",
+        name="restraint_category",
+    )
+    restraint_mech = sa.Enum("chain", "hinged", "rigid", name="restraint_mechanical_type")
+    user_role.create(op.get_bind(), checkfirst=True)
+    person_origin.create(op.get_bind(), checkfirst=True)
+    catalog_status.create(op.get_bind(), checkfirst=True)
+    restraint_category.create(op.get_bind(), checkfirst=True)
+    restraint_mech.create(op.get_bind(), checkfirst=True)
+
+    # -- person -------------------------------------------------------------
+    op.create_table(
+        "person",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(200), nullable=False),
+        sa.Column("alias", sa.String(200), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column(
+            "origin",
+            sa.dialects.postgresql.ENUM(name="person_origin", create_type=False),
+            nullable=False,
+            server_default="managed",
+        ),
+        sa.Column(
+            "linkable",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "is_deleted",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        # created_by FK is added later (after user table exists), via ALTER.
+        sa.Column("created_by", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_person_name", "person", ["name"])
+    op.create_index("ix_person_origin", "person", ["origin"])
+    op.create_index("ix_person_linkable", "person", ["linkable"])
+    op.create_index("ix_person_is_deleted", "person", ["is_deleted"])
+
+    # -- user ---------------------------------------------------------------
+    op.create_table(
+        "user",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("email", sa.String(320), nullable=False),
+        sa.Column("hashed_password", sa.String(1024), nullable=False),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "is_verified",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "is_superuser",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "role",
+            sa.dialects.postgresql.ENUM(name="user_role", create_type=False),
+            nullable=False,
+        ),
+        sa.Column(
+            "person_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("person.id", ondelete="RESTRICT", name="fk_user_person_id_person"),
+            nullable=False,
+        ),
+        sa.Column("display_name", sa.String(200), nullable=True),
+        sa.Column(
+            "is_deleted",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("email", name="uq_user_email"),
+        sa.UniqueConstraint("person_id", name="uq_user_person_id"),
+    )
+    op.create_index("ix_user_role", "user", ["role"])
+
+    # Now that user exists, add person.created_by FK back to it.
+    op.create_foreign_key(
+        "fk_person_created_by_user",
+        "person",
+        "user",
+        ["created_by"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    # -- event --------------------------------------------------------------
+    op.create_table(
+        "event",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("lat", sa.Numeric(9, 6), nullable=False),
+        sa.Column("lon", sa.Numeric(9, 6), nullable=False),
+        sa.Column(
+            "geom",
+            Geography(geometry_type="POINT", srid=4326),
+            sa.Computed(
+                "ST_SetSRID(ST_MakePoint(lon, lat), 4326)::geography",
+                persisted=True,
+            ),
+            nullable=False,
+        ),
+        sa.Column("w3w_legacy", sa.Text(), nullable=True),
+        sa.Column(
+            "reveal_participants",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column(
+            "created_by",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL", name="fk_event_created_by_user"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint("lat >= -90 AND lat <= 90", name="lat_range"),
+        sa.CheckConstraint("lon >= -180 AND lon <= 180", name="lon_range"),
+    )
+    op.create_index("ix_event_started_at", "event", ["started_at"])
+    op.create_index("ix_event_ended_at", "event", ["ended_at"])
+    op.create_index("ix_event_created_by", "event", ["created_by"])
+    op.execute("CREATE INDEX ix_event_geom ON event USING GIST (geom)")
+    op.execute(
+        "CREATE INDEX ix_event_note_fts ON event "
+        "USING GIN (to_tsvector('german', coalesce(note, '')))"
+    )
+
+    # -- event_participant --------------------------------------------------
+    op.create_table(
+        "event_participant",
+        sa.Column(
+            "event_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "event.id", ondelete="CASCADE", name="fk_event_participant_event_id_event"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "person_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "person.id", ondelete="RESTRICT", name="fk_event_participant_person_id_person"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("event_id", "person_id", name="pk_event_participant"),
+    )
+    op.create_index("ix_event_participant_person_id", "event_participant", ["person_id"])
+
+    # -- catalog: arm_position, hand_position, hand_orientation -------------
+    for tname in ("arm_position", "hand_position", "hand_orientation"):
+        op.create_table(
+            tname,
+            sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+            sa.Column("name", sa.String(120), nullable=False),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column(
+                "status",
+                sa.dialects.postgresql.ENUM(name="catalog_status", create_type=False),
+                nullable=False,
+                server_default="pending",
+            ),
+            sa.Column(
+                "suggested_by",
+                sa.dialects.postgresql.UUID(as_uuid=True),
+                sa.ForeignKey(
+                    "user.id",
+                    ondelete="SET NULL",
+                    name=f"fk_{tname}_suggested_by_user",
+                ),
+                nullable=True,
+            ),
+            sa.Column(
+                "approved_by",
+                sa.dialects.postgresql.UUID(as_uuid=True),
+                sa.ForeignKey(
+                    "user.id",
+                    ondelete="SET NULL",
+                    name=f"fk_{tname}_approved_by_user",
+                ),
+                nullable=True,
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+            sa.UniqueConstraint("name", name=f"uq_{tname}_name"),
+        )
+        op.create_index(f"ix_{tname}_status", tname, ["status"])
+
+    # -- restraint_type -----------------------------------------------------
+    op.create_table(
+        "restraint_type",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "category",
+            sa.dialects.postgresql.ENUM(name="restraint_category", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("brand", sa.String(120), nullable=True),
+        sa.Column("model", sa.String(200), nullable=True),
+        sa.Column(
+            "mechanical_type",
+            sa.dialects.postgresql.ENUM(name="restraint_mechanical_type", create_type=False),
+            nullable=True,
+        ),
+        sa.Column("display_name", sa.String(300), nullable=False),
+        sa.Column(
+            "status",
+            sa.dialects.postgresql.ENUM(name="catalog_status", create_type=False),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column(
+            "suggested_by",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "user.id", ondelete="SET NULL", name="fk_restraint_type_suggested_by_user"
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "approved_by",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "user.id", ondelete="SET NULL", name="fk_restraint_type_approved_by_user"
+            ),
+            nullable=True,
+        ),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint(
+            "category",
+            "brand",
+            "model",
+            "mechanical_type",
+            name="uq_restraint_type_identity",
+            postgresql_nulls_not_distinct=True,
+        ),
+    )
+    op.create_index("ix_restraint_type_status", "restraint_type", ["status"])
+    op.create_index("ix_restraint_type_category", "restraint_type", ["category"])
+    op.create_index("ix_restraint_type_brand", "restraint_type", ["brand"])
+
+    # -- application --------------------------------------------------------
+    op.create_table(
+        "application",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "event_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("event.id", ondelete="CASCADE", name="fk_application_event_id_event"),
+            nullable=False,
+        ),
+        sa.Column(
+            "performer_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "person.id", ondelete="RESTRICT", name="fk_application_performer_id_person"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "recipient_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "person.id", ondelete="RESTRICT", name="fk_application_recipient_id_person"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "arm_position_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "arm_position.id",
+                ondelete="RESTRICT",
+                name="fk_application_arm_position_id_arm_position",
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "hand_position_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "hand_position.id",
+                ondelete="RESTRICT",
+                name="fk_application_hand_position_id_hand_position",
+            ),
+            nullable=True,
+        ),
+        sa.Column(
+            "hand_orientation_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "hand_orientation.id",
+                ondelete="RESTRICT",
+                name="fk_application_hand_orientation_id_hand_orientation",
+            ),
+            nullable=True,
+        ),
+        sa.Column("sequence_no", sa.Integer(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column(
+            "created_by",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL", name="fk_application_created_by_user"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("event_id", "sequence_no", name="uq_application_event_sequence"),
+    )
+    op.create_index("ix_application_event_id", "application", ["event_id"])
+    op.create_index("ix_application_performer_id", "application", ["performer_id"])
+    op.create_index("ix_application_recipient_id", "application", ["recipient_id"])
+    op.create_index(
+        "ix_application_event_id_sequence_no",
+        "application",
+        ["event_id", "sequence_no"],
+    )
+    op.execute(
+        "CREATE INDEX ix_application_note_fts ON application "
+        "USING GIN (to_tsvector('german', coalesce(note, '')))"
+    )
+
+    # -- application_restraint ---------------------------------------------
+    op.create_table(
+        "application_restraint",
+        sa.Column(
+            "application_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "application.id",
+                ondelete="CASCADE",
+                name="fk_application_restraint_application_id_application",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "restraint_type_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "restraint_type.id",
+                ondelete="RESTRICT",
+                name="fk_application_restraint_restraint_type_id_restraint_type",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint(
+            "application_id", "restraint_type_id", name="pk_application_restraint"
+        ),
+    )
+    op.create_index(
+        "ix_application_restraint_restraint_type_id",
+        "application_restraint",
+        ["restraint_type_id"],
+    )
+
+    # -- updated_at triggers -----------------------------------------------
+    for tname in _UPDATED_AT_TABLES:
+        op.execute(
+            f"CREATE TRIGGER set_updated_at_{tname} "
+            f'BEFORE UPDATE ON "{tname}" '
+            f"FOR EACH ROW EXECUTE FUNCTION set_updated_at()"
+        )
+
+    # -- Grant baseline privileges to app_user -----------------------------
+    # Schema usage and full DML on all tables we just created.
+    op.execute("GRANT USAGE ON SCHEMA public TO app_user")
+    op.execute("GRANT SELECT, INSERT, UPDATE, DELETE " "ON ALL TABLES IN SCHEMA public TO app_user")
+    op.execute("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_user")
+
+    # -- RLS: enable + permissive default policy (M2 will replace with strict)
+    for tname in _RLS_TABLES:
+        op.execute(f'ALTER TABLE "{tname}" ENABLE ROW LEVEL SECURITY')
+        op.execute(f'ALTER TABLE "{tname}" FORCE ROW LEVEL SECURITY')
+        op.execute(
+            f'CREATE POLICY {tname}_default_permissive ON "{tname}" '
+            f"FOR ALL TO app_user USING (true) WITH CHECK (true)"
+        )
+
+
+def downgrade() -> None:
+    # Reverse order of creation; triggers and policies come down with their
+    # tables, so drop tables explicitly.
+    op.execute("DROP TABLE IF EXISTS application_restraint CASCADE")
+    op.execute("DROP TABLE IF EXISTS application CASCADE")
+    op.execute("DROP TABLE IF EXISTS restraint_type CASCADE")
+    for tname in ("hand_orientation", "hand_position", "arm_position"):
+        op.execute(f"DROP TABLE IF EXISTS {tname} CASCADE")
+    op.execute("DROP TABLE IF EXISTS event_participant CASCADE")
+    op.execute("DROP TABLE IF EXISTS event CASCADE")
+    op.execute('DROP TABLE IF EXISTS "user" CASCADE')
+    op.execute("DROP TABLE IF EXISTS person CASCADE")
+
+    op.execute("DROP FUNCTION IF EXISTS set_updated_at() CASCADE")
+
+    for enum_name in (
+        "user_role",
+        "person_origin",
+        "catalog_status",
+        "restraint_category",
+        "restraint_mechanical_type",
+    ):
+        op.execute(f"DROP TYPE IF EXISTS {enum_name}")
+
+    op.execute("REVOKE ALL ON SCHEMA public FROM app_user")
+    op.execute("DROP ROLE IF EXISTS app_user")
+    # PostGIS extension is intentionally NOT dropped (might be shared).

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,6 +10,12 @@ dependencies = [
     "pydantic>=2.9,<3",
     "pydantic-settings>=2.6,<3",
     "structlog>=24.4,<25",
+    "sqlalchemy[asyncio]>=2.0.36,<3",
+    "alembic>=1.14,<2",
+    "asyncpg>=0.30,<0.31",
+    "psycopg[binary]>=3.2,<4",
+    "geoalchemy2>=0.15,<0.16",
+    "uuid-utils>=0.10,<0.11",
 ]
 
 [dependency-groups]
@@ -19,6 +25,7 @@ dev = [
     "pytest>=8.3,<9",
     "pytest-asyncio>=0.24,<0.25",
     "httpx>=0.27,<0.28",
+    "testcontainers[postgresql]>=4.8,<5",
 ]
 
 [build-system]
@@ -60,4 +67,5 @@ disallow_untyped_defs = false
 [tool.pytest.ini_options]
 addopts = "-ra --strict-markers"
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
 testpaths = ["tests"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,18 +1,98 @@
-"""Shared pytest fixtures."""
+"""Shared pytest fixtures.
+
+DB tests use a sync engine (psycopg) so session-scoped fixtures can be
+shared across function-scoped tests without event-loop juggling. The
+production app uses asyncpg; the schema is the same.
+
+DSN resolution:
+1. ``HCMAP_TEST_DATABASE_URL`` (preferred for CI / dev with local Postgres).
+2. testcontainers ``postgis/postgis:16-3.4`` (skipped if Docker missing).
+"""
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+import os
+from collections.abc import AsyncIterator, Iterator
 
 import pytest
 from app.main import create_app
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
 
 
 @pytest.fixture
 async def client() -> AsyncIterator[AsyncClient]:
-    """Provide an in-process AsyncClient bound to a fresh app instance."""
+    """In-process AsyncClient bound to a fresh app instance."""
     app = create_app()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         yield ac
+
+
+# ---------------------------------------------------------------------------
+# Database fixtures (sync; M1 schema tests don't need async)
+# ---------------------------------------------------------------------------
+
+
+def _to_sync_url(url: str) -> str:
+    return url.replace("+asyncpg", "+psycopg") if "+asyncpg" in url else url
+
+
+@pytest.fixture(scope="session")
+def db_url() -> Iterator[str]:
+    env_dsn = os.environ.get("HCMAP_TEST_DATABASE_URL")
+    if env_dsn:
+        yield _to_sync_url(env_dsn)
+        return
+
+    try:
+        from testcontainers.postgres import PostgresContainer
+    except ImportError:
+        pytest.skip("HCMAP_TEST_DATABASE_URL not set and testcontainers not installed")
+        return
+    if not os.path.exists("/var/run/docker.sock"):
+        pytest.skip("HCMAP_TEST_DATABASE_URL not set and Docker daemon is unreachable")
+        return
+    with PostgresContainer("postgis/postgis:16-3.4") as pg:
+        sync_url = pg.get_connection_url()  # postgresql+psycopg2://...
+        if "+psycopg2" in sync_url:
+            sync_url = sync_url.replace("+psycopg2", "+psycopg")
+        yield sync_url
+
+
+@pytest.fixture(scope="session")
+def db_engine(db_url: str) -> Iterator[Engine]:
+    """Session-scoped sync engine. Migrates from scratch once per session."""
+    from alembic import command
+    from alembic.config import Config
+
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(db_url, future=True)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def db_session(db_engine: Engine) -> Iterator[Session]:
+    """Function-scoped session. Each test runs inside a transaction that is
+    rolled back on exit, so tests stay independent without dropping tables."""
+    SessionLocal = sessionmaker(bind=db_engine, expire_on_commit=False, autoflush=False)
+    conn = db_engine.connect()
+    trans = conn.begin()
+    sess = SessionLocal(bind=conn)
+    try:
+        yield sess
+    finally:
+        sess.close()
+        # IntegrityError-aborted transactions are auto-deassociated;
+        # rollback is harmless but emits a SAWarning. Guard it.
+        if trans.is_active:
+            trans.rollback()
+        conn.close()

--- a/backend/tests/test_migration.py
+++ b/backend/tests/test_migration.py
@@ -1,0 +1,52 @@
+"""Migration smoke tests (Fahrplan: M1 acceptance criterion)."""
+
+from __future__ import annotations
+
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Engine
+
+EXPECTED_TABLES = {
+    "alembic_version",
+    "application",
+    "application_restraint",
+    "arm_position",
+    "event",
+    "event_participant",
+    "hand_orientation",
+    "hand_position",
+    "person",
+    "restraint_type",
+    "spatial_ref_sys",  # PostGIS-managed
+    "user",
+}
+
+
+def test_all_tables_present(db_engine: Engine) -> None:
+    with db_engine.connect() as conn:
+        names = set(inspect(conn).get_table_names())
+    assert EXPECTED_TABLES.issubset(names), EXPECTED_TABLES - names
+
+
+def test_postgis_extension_active(db_engine: Engine) -> None:
+    with db_engine.connect() as conn:
+        version = conn.execute(text("SELECT PostGIS_Version()")).scalar_one()
+        assert version.startswith("3."), version
+
+
+def test_app_user_role_exists(db_engine: Engine) -> None:
+    with db_engine.connect() as conn:
+        present = conn.execute(text("SELECT 1 FROM pg_roles WHERE rolname = 'app_user'")).scalar()
+    assert present == 1
+
+
+def test_rls_enabled_on_data_tables(db_engine: Engine) -> None:
+    with db_engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                "SELECT relname FROM pg_class "
+                "WHERE relrowsecurity = true AND relkind = 'r' "
+                "ORDER BY relname"
+            )
+        ).all()
+    rls_tables = {r[0] for r in rows}
+    assert {"event", "event_participant", "application", "application_restraint"} <= rls_tables

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,99 @@
+"""Model-level constraint and behaviour tests (Fahrplan: M1 DoD)."""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+
+import pytest
+from app.models import Event, Person, User, UserRole
+from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+
+def _make_admin(session: Session) -> tuple[Person, User]:
+    person = Person(name="Admin Person")
+    session.add(person)
+    session.flush()
+    user = User(
+        email="admin@example.invalid",
+        hashed_password="argon2id$dummy",
+        role=UserRole.ADMIN,
+        person_id=person.id,
+    )
+    session.add(user)
+    session.flush()
+    return person, user
+
+
+def test_user_email_unique(db_session: Session) -> None:
+    _, user = _make_admin(db_session)
+    p2 = Person(name="Other")
+    db_session.add(p2)
+    db_session.flush()
+    db_session.add(
+        User(
+            email=user.email,
+            hashed_password="x",
+            role=UserRole.VIEWER,
+            person_id=p2.id,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+def test_user_person_link_unique(db_session: Session) -> None:
+    person, _ = _make_admin(db_session)
+    db_session.add(
+        User(
+            email="other@example.invalid",
+            hashed_password="x",
+            role=UserRole.EDITOR,
+            person_id=person.id,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+def test_event_lat_check_constraint(db_session: Session) -> None:
+    db_session.add(
+        Event(
+            started_at=datetime.now(tz=UTC),
+            lat=95,
+            lon=0,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+def test_event_geom_is_computed(db_session: Session) -> None:
+    event = Event(
+        started_at=datetime.now(tz=UTC),
+        lat=52.520008,
+        lon=13.404954,
+    )
+    db_session.add(event)
+    db_session.flush()
+    wkt = db_session.execute(
+        text("SELECT ST_AsText(geom::geometry) FROM event WHERE id = :id"),
+        {"id": event.id},
+    ).scalar_one()
+    assert wkt == "POINT(13.404954 52.520008)"
+
+
+def test_updated_at_trigger_fires(db_session: Session) -> None:
+    person, _ = _make_admin(db_session)
+    db_session.flush()
+    assert person.updated_at is None
+    time.sleep(0.05)
+    person.alias = "Patrick"
+    db_session.flush()
+    updated = db_session.execute(
+        select(Person.updated_at).where(Person.id == person.id)
+    ).scalar_one()
+    assert updated is not None
+    assert updated > person.created_at

--- a/backend/tests/test_seeds.py
+++ b/backend/tests/test_seeds.py
@@ -1,0 +1,76 @@
+"""Seed-script idempotency tests (Fahrplan: M1 DoD)."""
+
+from __future__ import annotations
+
+from app.models.base import uuid7
+from app.seeds.positions import (
+    ARM_POSITIONS,
+    HAND_ORIENTATIONS,
+    HAND_POSITIONS,
+    insert_sql,
+)
+from app.seeds.restraint_types import INSERT_SQL as RESTRAINT_TYPE_SQL
+from app.seeds.restraint_types import SEEDS as RESTRAINT_TYPE_SEEDS
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+
+def _seed_once(db_engine: Engine) -> dict[str, int]:
+    rt_stmt = text(RESTRAINT_TYPE_SQL.replace("gen_random_uuid()", ":id"))
+    counts = {
+        "restraint_type": 0,
+        "arm_position": 0,
+        "hand_position": 0,
+        "hand_orientation": 0,
+    }
+    with db_engine.begin() as conn:
+        for s in RESTRAINT_TYPE_SEEDS:
+            r = conn.execute(
+                rt_stmt,
+                {
+                    "id": uuid7(),
+                    "category": s.category,
+                    "brand": s.brand,
+                    "model": s.model,
+                    "mechanical_type": s.mechanical_type,
+                    "display_name": s.display_name,
+                },
+            )
+            counts["restraint_type"] += r.rowcount or 0
+        for table, names in (
+            ("arm_position", ARM_POSITIONS),
+            ("hand_position", HAND_POSITIONS),
+            ("hand_orientation", HAND_ORIENTATIONS),
+        ):
+            stmt = text(insert_sql(table))
+            for name in names:
+                r = conn.execute(stmt, {"id": uuid7(), "name": name})
+                counts[table] += r.rowcount or 0
+    return counts
+
+
+def test_seed_first_run_inserts_all(db_engine: Engine) -> None:
+    with db_engine.begin() as conn:
+        for table in (
+            "arm_position",
+            "hand_position",
+            "hand_orientation",
+            "restraint_type",
+        ):
+            conn.execute(text(f'TRUNCATE "{table}" CASCADE'))
+    counts = _seed_once(db_engine)
+    assert counts["restraint_type"] == len(RESTRAINT_TYPE_SEEDS)
+    assert counts["arm_position"] == len(ARM_POSITIONS)
+    assert counts["hand_position"] == len(HAND_POSITIONS)
+    assert counts["hand_orientation"] == len(HAND_ORIENTATIONS)
+
+
+def test_seed_second_run_is_noop(db_engine: Engine) -> None:
+    _seed_once(db_engine)
+    counts = _seed_once(db_engine)
+    assert counts == {
+        "restraint_type": 0,
+        "arm_position": 0,
+        "hand_position": 0,
+        "hand_orientation": 0,
+    }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3,6 +3,20 @@ revision = 3
 requires-python = "==3.12.*"
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -25,12 +39,53 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/4c/7c991e080e106d854809030d8584e15b2e996e26f16aee6d757e387bc17d/asyncpg-0.30.0.tar.gz", hash = "sha256:c551e9928ab6707602f44811817f82ba3c446e018bfe1d3abecc8ba5f3eac851", size = 957746, upload-time = "2024-10-20T00:30:41.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/64/9d3e887bb7b01535fdbc45fbd5f0a8447539833b97ee69ecdbb7a79d0cb4/asyncpg-0.30.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c902a60b52e506d38d7e80e0dd5399f657220f24635fee368117b8b5fce1142e", size = 673162, upload-time = "2024-10-20T00:29:41.88Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/eb/8b236663f06984f212a087b3e849731f917ab80f84450e943900e8ca4052/asyncpg-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:aca1548e43bbb9f0f627a04666fedaca23db0a31a84136ad1f868cb15deb6e3a", size = 637025, upload-time = "2024-10-20T00:29:43.352Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/57/2dc240bb263d58786cfaa60920779af6e8d32da63ab9ffc09f8312bd7a14/asyncpg-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c2a2ef565400234a633da0eafdce27e843836256d40705d83ab7ec42074efb3", size = 3496243, upload-time = "2024-10-20T00:29:44.922Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/40/0ae9d061d278b10713ea9021ef6b703ec44698fe32178715a501ac696c6b/asyncpg-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1292b84ee06ac8a2ad8e51c7475aa309245874b61333d97411aab835c4a2f737", size = 3575059, upload-time = "2024-10-20T00:29:46.891Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/75/d6b895a35a2c6506952247640178e5f768eeb28b2e20299b6a6f1d743ba0/asyncpg-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0f5712350388d0cd0615caec629ad53c81e506b1abaaf8d14c93f54b35e3595a", size = 3473596, upload-time = "2024-10-20T00:29:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e7/3693392d3e168ab0aebb2d361431375bd22ffc7b4a586a0fc060d519fae7/asyncpg-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db9891e2d76e6f425746c5d2da01921e9a16b5a71a1c905b13f30e12a257c4af", size = 3641632, upload-time = "2024-10-20T00:29:50.768Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ea/15670cea95745bba3f0352341db55f506a820b21c619ee66b7d12ea7867d/asyncpg-0.30.0-cp312-cp312-win32.whl", hash = "sha256:68d71a1be3d83d0570049cd1654a9bdfe506e794ecc98ad0873304a9f35e411e", size = 560186, upload-time = "2024-10-20T00:29:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/6b/fe1fad5cee79ca5f5c27aed7bd95baee529c1bf8a387435c8ba4fe53d5c1/asyncpg-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:9a0292c6af5c500523949155ec17b7fe01a00ace33b68a476d6b5059f9630305", size = 621064, upload-time = "2024-10-20T00:29:53.757Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -55,6 +110,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.115.14"
 source = { registry = "https://pypi.org/simple" }
@@ -66,6 +135,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/53/8c38a874844a8b0fa10dd8adf3836ac154082cf88d3f22b544e9ceea0a15/fastapi-0.115.14.tar.gz", hash = "sha256:b1de15cdc1c499a4da47914db35d0e4ef8f1ce62b624e94e0e5824421df99739", size = 296263, upload-time = "2025-06-26T15:29:08.21Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/50/b1222562c6d270fea83e9c9075b8e8600b8479150a18e4516a6138b980d1/fastapi-0.115.14-py3-none-any.whl", hash = "sha256:6c0c8bf9420bd58f565e585036d971872472b4f7d3f6c73b698e10cffdefb3ca", size = 95514, upload-time = "2025-06-26T15:29:06.49Z" },
+]
+
+[[package]]
+name = "geoalchemy2"
+version = "0.15.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/38/bac6dce23250751ce448f5d21b31aed68b2ac5d8a8b4ca267b9a44c12dd4/geoalchemy2-0.15.2.tar.gz", hash = "sha256:3af0272db927373e74ee3b064cdc9464ba08defdb945c51745db1b841482f5dc", size = 225642, upload-time = "2024-07-10T18:53:36.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/f7/a71bbed7252af7db0746b81b83d68bd400f169e49d3726072e547774d949/GeoAlchemy2-0.15.2-py3-none-any.whl", hash = "sha256:546455dc39f5bcdfc5b871e57d3f7546c8a6f798eb364c474200f488ace6fd32", size = 73601, upload-time = "2024-07-10T18:53:34.151Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
+    { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
+    { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
+    { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/47/6c41314bac56e71436ce551c7fbe3cc830ed857e6aa9708dbb9c65142eb6/greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e", size = 235599, upload-time = "2026-04-08T15:52:54.3Z" },
 ]
 
 [[package]]
@@ -82,10 +182,16 @@ name = "hc-map-backend"
 version = "0.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "alembic" },
+    { name = "asyncpg" },
     { name = "fastapi" },
+    { name = "geoalchemy2" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
+    { name = "uuid-utils" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -96,14 +202,21 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "testcontainers" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.14,<2" },
+    { name = "asyncpg", specifier = ">=0.30,<0.31" },
     { name = "fastapi", specifier = ">=0.115,<0.116" },
+    { name = "geoalchemy2", specifier = ">=0.15,<0.16" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2,<4" },
     { name = "pydantic", specifier = ">=2.9,<3" },
     { name = "pydantic-settings", specifier = ">=2.6,<3" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.36,<3" },
     { name = "structlog", specifier = ">=24.4,<25" },
+    { name = "uuid-utils", specifier = ">=0.10,<0.11" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32,<0.33" },
 ]
 
@@ -114,6 +227,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3,<9" },
     { name = "pytest-asyncio", specifier = ">=0.24,<0.25" },
     { name = "ruff", specifier = ">=0.7,<0.8" },
+    { name = "testcontainers", extras = ["postgresql"], specifier = ">=4.8,<5" },
 ]
 
 [[package]]
@@ -200,6 +314,37 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
@@ -255,6 +400,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/15/021be5c0cbc5b7c1ab46e91cc3434eb42569f79a0592e67b8d25e66d844d/psycopg_binary-3.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6698dbab5bcef8fdb570fc9d35fd9ac52041771bfcfe6fd0fc5f5c4e36f1e99d", size = 4591170, upload-time = "2026-02-18T16:48:55.594Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/54/a60211c346c9a2f8c6b272b5f2bbe21f6e11800ce7f61e99ba75cf8b63e1/psycopg_binary-3.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:329ff393441e75f10b673ae99ab45276887993d49e65f141da20d915c05aafd8", size = 4670009, upload-time = "2026-02-18T16:49:03.608Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/53/ac7c18671347c553362aadbf65f92786eef9540676ca24114cc02f5be405/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:eb072949b8ebf4082ae24289a2b0fd724da9adc8f22743409d6fd718ddb379df", size = 5469735, upload-time = "2026-02-18T16:49:10.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c3/4f4e040902b82a344eff1c736cde2f2720f127fe939c7e7565706f96dd44/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:263a24f39f26e19ed7fc982d7859a36f17841b05bebad3eb47bb9cd2dd785351", size = 5152919, upload-time = "2026-02-18T16:49:16.335Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e7/d929679c6a5c212bcf738806c7c89f5b3d0919f2e1685a0e08d6ff877945/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5152d50798c2fa5bd9b68ec68eb68a1b71b95126c1d70adaa1a08cd5eefdc23d", size = 6738785, upload-time = "2026-02-18T16:49:22.687Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b0/09703aeb69a9443d232d7b5318d58742e8ca51ff79f90ffe6b88f1db45e7/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d6a1e56dd267848edb824dbeb08cf5bac649e02ee0b03ba883ba3f4f0bd54f2", size = 4979008, upload-time = "2026-02-18T16:49:27.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a6/e662558b793c6e13a7473b970fee327d635270e41eded3090ef14045a6a5/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73eaaf4bb04709f545606c1db2f65f4000e8a04cdbf3e00d165a23004692093e", size = 4508255, upload-time = "2026-02-18T16:49:31.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7f/0f8b2e1d5e0093921b6f324a948a5c740c1447fbb45e97acaf50241d0f39/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:162e5675efb4704192411eaf8e00d07f7960b679cd3306e7efb120bb8d9456cc", size = 4189166, upload-time = "2026-02-18T16:49:35.801Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ec/ce2e91c33bc8d10b00c87e2f6b0fb570641a6a60042d6a9ae35658a3a797/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:fab6b5e37715885c69f5d091f6ff229be71e235f272ebaa35158d5a46fd548a0", size = 3924544, upload-time = "2026-02-18T16:49:41.129Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/2f/7718141485f73a924205af60041c392938852aa447a94c8cbd222ff389a1/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a4aab31bd6d1057f287c96c0effca3a25584eb9cc702f282ecb96ded7814e830", size = 4235297, upload-time = "2026-02-18T16:49:46.726Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f9/1add717e2643a003bbde31b1b220172e64fbc0cb09f06429820c9173f7fc/psycopg_binary-3.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:59aa31fe11a0e1d1bcc2ce37ed35fe2ac84cd65bb9036d049b1a1c39064d0f14", size = 3547659, upload-time = "2026-02-18T16:49:52.999Z" },
 ]
 
 [[package]]
@@ -363,6 +544,16 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -378,6 +569,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
     { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
     { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -415,6 +621,31 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/b3/2de412451330756aaaa72d27131db6dde23995efe62c941184e15242a5fa/sqlalchemy-2.0.49-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b", size = 2157681, upload-time = "2026-04-03T16:53:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/50/84/b2a56e2105bd11ebf9f0b93abddd748e1a78d592819099359aa98134a8bf/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982", size = 3338976, upload-time = "2026-04-03T17:07:40Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672", size = 3351937, upload-time = "2026-04-03T17:12:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2f/6fd118563572a7fe475925742eb6b3443b2250e346a0cc27d8d408e73773/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e", size = 3281646, upload-time = "2026-04-03T17:07:41.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d7/410f4a007c65275b9cf82354adb4bb8ba587b176d0a6ee99caa16fe638f8/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750", size = 3316695, upload-time = "2026-04-03T17:12:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/95/81f594aa60ded13273a844539041ccf1e66c5a7bed0a8e27810a3b52d522/sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0", size = 2117483, upload-time = "2026-04-03T17:05:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9e/fd90114059175cac64e4fafa9bf3ac20584384d66de40793ae2e2f26f3bb/sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4", size = 2144494, upload-time = "2026-04-03T17:05:42.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.46.2"
 source = { registry = "https://pypi.org/simple" }
@@ -436,6 +667,22 @@ wheels = [
 ]
 
 [[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -454,6 +701,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uuid-utils"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/0a/cbdb2eb4845dafeb632d02a18f47b02f87f2ce4f25266f5e3c017976ce89/uuid_utils-0.10.0.tar.gz", hash = "sha256:5db0e1890e8f008657ffe6ded4d9459af724ab114cfe82af1557c87545301539", size = 18828, upload-time = "2024-11-21T13:57:40.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/54/9d22fa16b19e5d1676eba510f08a9c458d96e2a62ff2c8ebad64251afb18/uuid_utils-0.10.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:8d5a4508feefec62456cd6a41bcdde458d56827d908f226803b886d22a3d5e63", size = 573006, upload-time = "2024-11-21T13:56:50.873Z" },
+    { url = "https://files.pythonhosted.org/packages/08/8e/f895c6e52aa603e521fbc13b8626ba5dd99b6e2f5a55aa96ba5b232f4c53/uuid_utils-0.10.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dbefc2b9113f9dfe56bdae58301a2b3c53792221410d422826f3d1e3e6555fe7", size = 292543, upload-time = "2024-11-21T13:56:54.677Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/58/cc4834f377a5e97d6e184408ad96d13042308de56643b6e24afe1f6f34df/uuid_utils-0.10.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffc49c33edf87d1ec8112a9b43e4cf55326877716f929c165a2cc307d31c73d5", size = 323340, upload-time = "2024-11-21T13:56:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e3/6aeddf148f6a7dd7759621b000e8c85382ec83f52ae79b60842d1dc3ab6b/uuid_utils-0.10.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0636b6208f69d5a4e629707ad2a89a04dfa8d1023e1999181f6830646ca048a1", size = 329653, upload-time = "2024-11-21T13:56:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/00/dd6c2164ace70b7b1671d9129267df331481d7d1e5f9c5e6a564f07953f6/uuid_utils-0.10.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc06452856b724df9dedfc161c3582199547da54aeb81915ec2ed54f92d19b0", size = 365471, upload-time = "2024-11-21T13:57:00.807Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e7/0ab8080fcae5462a7b5e555c1cef3d63457baffb97a59b9bc7b005a3ecb1/uuid_utils-0.10.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:263b2589111c61decdd74a762e8f850c9e4386fb78d2cf7cb4dfc537054cda1b", size = 325844, upload-time = "2024-11-21T13:57:02.309Z" },
+    { url = "https://files.pythonhosted.org/packages/73/39/52d94e9ef75b03f44b39ffc6ac3167e93e74ef4d010a93d25589d9f48540/uuid_utils-0.10.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a558db48b7096de6b4d2d2210d82bba8586a6d55f99106b03bb7d01dc5c5bcd6", size = 344389, upload-time = "2024-11-21T13:57:03.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/4824566f62666238290d99c62a58e4ab2a8b9cf2eccf94cebd9b3359131e/uuid_utils-0.10.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:807465067f3c892514230326ac71a79b28a8dfe2c88ecd2d5675fc844f3c76b5", size = 510078, upload-time = "2024-11-21T13:57:06.093Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8f/bbcc7130d652462c685f0d3bd26bb214b754215b476340885a4cb50fb89a/uuid_utils-0.10.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:57423d4a2b9d7b916de6dbd75ba85465a28f9578a89a97f7d3e098d9aa4e5d4a", size = 515937, upload-time = "2024-11-21T13:57:07.855Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f8/34e0c00f5f188604d336713e6a020fcf53b10998e8ab24735a39ab076740/uuid_utils-0.10.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:76d8d660f18ff6b767e319b1b5f927350cd92eafa4831d7ef5b57fdd1d91f974", size = 494111, upload-time = "2024-11-21T13:57:09.511Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/52/b7f0066cc90a7a9c28d54061ed195cd617fde822e5d6ac3ccc88509c3c44/uuid_utils-0.10.0-cp39-abi3-win32.whl", hash = "sha256:6c11a71489338837db0b902b75e1ba7618d5d29f05fde4f68b3f909177dbc226", size = 173520, upload-time = "2024-11-21T13:57:11.654Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/15/f04f58094674d333974243fb45d2c740cf4b79186fb707168e57943c84a3/uuid_utils-0.10.0-cp39-abi3-win_amd64.whl", hash = "sha256:11c55ae64f6c0a7a0c741deae8ca2a4eaa11e9c09dbb7bec2099635696034cf7", size = 182965, upload-time = "2024-11-21T13:57:13.709Z" },
 ]
 
 [[package]]
@@ -534,4 +819,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
     { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -988,6 +988,80 @@ Folgende Punkte werden als ADRs dokumentiert, sobald sie in der Architekturphase
 
 ---
 
+## ADR-018 — Implementierungsstrategie M1 (Datenmodell, Migrations, Seeds, RLS-Default)
+
+**Status:** Akzeptiert (2026-04-25)
+
+**Kontext:** M1 setzt das in `architecture.md` §Datenmodell spezifizierte Schema
+um. Architecture-Doku lässt mehrere Implementierungsdetails offen, die für
+einen lauffähigen ersten Migrationsstand entschieden sein müssen.
+
+**Entscheidungen:**
+
+1. **Neue Backend-Dependencies** (alle MIT/BSD/Apache, lizenzkonform §6):
+   - `sqlalchemy[asyncio]>=2.0` (ADR-005 explizit)
+   - `alembic>=1.14` (ADR-005 explizit)
+   - `asyncpg>=0.30` — Standard-Async-Treiber für Postgres
+   - `geoalchemy2>=0.15` — PostGIS-Spalten in SQLAlchemy
+   - `uuid-utils>=0.10` — UUIDv7-Generation client-seitig
+   - `testcontainers[postgresql]>=4` — echtes Postgres+PostGIS in Tests
+   - `psycopg[binary]>=3.2` — Sync-Treiber für Alembic-Offline-Operationen
+
+2. **UUIDv7-Strategie:** Client-seitig via `uuid_utils.uuid7()` als
+   SQLAlchemy-`default`. Postgres 16 hat keine native v7-Funktion; eine
+   PL/pgSQL-Implementierung würde Schema-Komplexität ohne Nutzen einführen.
+
+3. **`updated_at`-Mechanik:** Postgres-Trigger `BEFORE UPDATE` pro Tabelle
+   (in der Migration). Greift auch bei direkten SQL-Schreibern (Admin,
+   data migrations) und bleibt unabhängig vom ORM.
+
+4. **RLS-Default in M1:** RLS auf allen daten-führenden Tabellen aktivieren
+   (`ENABLE` + `FORCE ROW LEVEL SECURITY`) und eine permissive Default-
+   Policy für die Anwendungs-Rolle anlegen (USING + WITH CHECK = `true`).
+   Dadurch sind RLS-Mechanik, Rolle und Connection-Setup ab M1 produktiv,
+   während die scharfen Rollen-Policies aus `architecture.md` §RLS
+   gemeinsam mit fastapi-users in M2 nachgezogen werden.
+
+5. **Anwendungs-Rolle:** Neue Postgres-Rolle `app_user` (NOLOGIN, NOSUPERUSER),
+   Eigentümer aller Anwendungs-Tabellen bleibt der Migrations-User.
+   Backend-Connections setzen `SET ROLE app_user` pro Session (genaue
+   Verdrahtung in M2 mit fastapi-users). RLS-Policies adressieren `app_user`.
+
+6. **Seed-Strategie:** Separate Skripte unter `backend/seeds/`, idempotent via
+   `INSERT ... ON CONFLICT DO NOTHING` auf den jeweiligen UNIQUE-Constraints.
+   CLI-Einstieg `uv run python -m app.seeds.run`. Architecture §Migrations
+   verbietet Seeds in Alembic explizit.
+
+7. **RestraintType-Seed-Inhalt:** In M1 nur die in `fahrplan.md` Z. 105
+   namentlich genannten Anker-Modelle (siehe `architecture.md` §Katalog-Seed),
+   plus die Material-Einträge. Die ausführliche
+   `restraint-types-seed-review.md` ist explizit als Vor-Sichtungsliste
+   markiert; ihre Übernahme passiert nach inhaltlicher Abnahme durch den
+   Admin in einem separaten Schritt.
+
+8. **Test-Infrastruktur:** Tests beziehen ihren Postgres-DSN bevorzugt aus
+   `HCMAP_TEST_DATABASE_URL`. Wenn nicht gesetzt, fällt eine Pytest-Fixture
+   auf `testcontainers` zurück (benötigt Docker). Dadurch lokale Entwicklung
+   und CI gleichermaßen möglich, ohne Code-Änderung.
+
+**Konsequenzen:**
+- M1-Migrationen sind in M2 nicht zu re-rollen: scharfe Policies werden als
+  zusätzliche Migration eingespielt, nicht durch Down-Migration ersetzt.
+- `app_user`-Rolle ist Voraussetzung für alle weiteren RLS-Tests in M2.
+- UUIDv7-Wechsel auf eine native Postgres-Funktion (z. B. nach Upgrade auf
+  Postgres 18) wäre eine reine Default-Substitution ohne Schema-Migration.
+
+**Verworfene Alternativen:**
+- B2 (PL/pgSQL-UUIDv7-Function): zu viel DB-Logik für minimalen Gewinn.
+- B3 (Vorerst v4): widerspricht `architecture.md` §Konventionen.
+- C2 (`onupdate=func.now()` ORM-seitig): greift nicht bei Direkt-SQL.
+- D2 (RLS erst in M2): Risiko, dass M1-Migration substantially geändert
+  werden muss.
+- E2 (Seeds in Alembic): widerspricht `architecture.md` §Migrations.
+- F2 (volle Sichtungsliste ohne Abnahme): widerspricht Datei-Kopfnote.
+
+---
+
 # Teil B — Entscheidungsregeln
 
 <!-- Wiederkehrende Muster, die aus ADRs hervorgehen.

--- a/docs/fahrplan.md
+++ b/docs/fahrplan.md
@@ -27,8 +27,8 @@ Status-Marker (gemäß CLAUDE.md Abschnitt 7):
 
 - **Stand vom:** 2026-04-25
 - **Laufende Phase:** Phase 1 (MVP) — gestartet
-- **Aktiver Schritt:** keiner (M0 abgeschlossen)
-- **Nächster Schritt:** M1 — Datenbank-Schema & Migrations (Datenmodell-Freigabe bereits erteilt; ADR-018 für Anpassungen wird mit M1-Beginn angelegt)
+- **Aktiver Schritt:** keiner (M1 abgeschlossen)
+- **Nächster Schritt:** M2 — Auth & User-Management (Backend) (baut die scharfen RLS-Policies auf der M1-Default-Policy auf, integriert fastapi-users und ergänzt das User-Modell um die produktive Auth-Bridge)
 - **Offene STOPP-Situationen:** keine
 
 ## Überblick
@@ -46,7 +46,7 @@ Jede Phase besteht aus nummerierten Meilensteinen (M0, M1, …). Innerhalb einer
 | Phase   | Meilenstein | Titel                                            | Status      |
 |---------|-------------|--------------------------------------------------|-------------|
 | 1 MVP   | M0          | Projekt-Setup                                    | [ERLEDIGT] 2026-04-25 |
-| 1 MVP   | M1          | Datenbank-Schema & Migrations                    | [OFFEN]     |
+| 1 MVP   | M1          | Datenbank-Schema & Migrations                    | [ERLEDIGT] 2026-04-25 |
 | 1 MVP   | M2          | Auth & User-Management (Backend)                 | [OFFEN]     |
 | 1 MVP   | M3          | Event- und Application-API (Backend)             | [OFFEN]     |
 | 1 MVP   | M4          | Frontend-Grundgerüst & Auth-Flow                 | [OFFEN]     |
@@ -129,6 +129,33 @@ Jede Phase besteht aus nummerierten Meilensteinen (M0, M1, …). Innerhalb einer
 - Model-Unit-Tests bestätigen Constraints und Beziehungen.
 
 **Abhängigkeiten:** M0.
+
+**Status `[ERLEDIGT]` 2026-04-25:**
+- 10 SQLAlchemy-Modelle in `backend/app/models/`, alle mit UUIDv7-PK,
+  `created_at`/`updated_at`/`created_by`. `event.geom` als
+  `geography(Point, 4326)` GENERATED ALWAYS AS STORED, GIST-Index. GIN-Indizes
+  auf `to_tsvector('german', note)` für Event und Application (vorbereitet
+  für M3-Volltextsuche).
+- Alembic-Initialmigration `20260425_1700_initial`: PostGIS-Extension,
+  `app_user`-Rolle, alle Tabellen+FKs+Constraints+Indizes, `set_updated_at`-
+  Trigger via `clock_timestamp()` auf 8 Tabellen, RLS aktiv (`ENABLE`+`FORCE`)
+  mit permissiver Default-Policy auf `event`, `event_participant`,
+  `application`, `application_restraint`. Scharfe Policies pro Rolle in M2.
+- env.py unterstützt sync (psycopg) und async (asyncpg) DSN; respektiert
+  vom Caller gesetzte URL.
+- Seed-Skripte unter `backend/app/seeds/` (`run.py`, `restraint_types.py`,
+  `positions.py`): 17 RestraintTypes (Anker-Modelle laut ADR-018 F1) +
+  8 ArmPositions + 4 HandPositions + 5 HandOrientations. Idempotent via
+  UNIQUE NULLS NOT DISTINCT + `ON CONFLICT DO NOTHING`. Inhaltliche
+  Übernahme der vollständigen `docs/restraint-types-seed-review.md` ist
+  Folge-Aufgabe nach Admin-Sichtung.
+- Tests: 13/13 grün gegen Postgres 16 + PostGIS 3.4 (Migration-Smoke,
+  Schema-Inventur, RLS-Aktivierung, UNIQUE/CHECK-Constraints, Computed
+  geom, updated_at-Trigger, Seed-Idempotenz). `ruff check`,
+  `ruff format --check`, `mypy --strict` clean.
+- ADR-018 in `docs/decisions.md` dokumentiert die Implementierungs-
+  Entscheidungen (UUIDv7-Strategie, Trigger-Mechanik, RLS-Default,
+  Seed-Strategie, Test-Infrastruktur).
 
 ---
 


### PR DESCRIPTION
Vollständiges initiales Schema gemäß docs/architecture.md §Datenmodell mit Implementierungs-Detail-Entscheidungen aus ADR-018.

SQLAlchemy 2.0 Modelle (10 Entitäten):
- User (fastapi-users-kompatibel), Person, Event, EventParticipant, Application, ApplicationRestraint, RestraintType, ArmPosition, HandPosition, HandOrientation
- UUIDv7-PKs via uuid-utils, timestamptz fuer alle Zeitfelder
- Geteilter catalog_status-Enum, vermeidet Postgres-Typkollisionen
- person.created_by als nullable FK mit use_alter, damit Person vor jedem User existieren kann (Bootstrap, w3w-Migration)

Alembic-Initialmigration 20260425_1700_initial:
- PostGIS-Extension, app_user-Rolle (NOLOGIN, fuer M2-RLS)
- 10 Tabellen, alle FKs mit ondelete-Strategie, alle Indizes
- event.geom als GENERATED geography(Point, 4326), GIST-Index
- GIN-Indizes auf to_tsvector('german', note) fuer Event und Application (vorbereitet fuer M3-Volltextsuche)
- UNIQUE(category,brand,model,mechanical_type) NULLS NOT DISTINCT
- set_updated_at-Trigger via clock_timestamp() auf 8 Tabellen
- RLS aktiv (ENABLE+FORCE) auf event, event_participant, application, application_restraint mit permissiver Default-Policy fuer app_user; M2 ersetzt durch scharfe Per-Rolle-Policies aus architecture.md
- env.py erkennt asyncpg vs. psycopg DSN, nutzt entsprechenden Engine

Seeds (idempotent, separate Skripte gemaess architecture.md):
- 17 RestraintTypes (Anker-Modelle laut ADR-018 Punkt F1: ASP/S&W/ Peerless/TCH/Clejuso Schellen + 6 Materialien) als status='approved'
- 8 ArmPositions, 4 HandPositions, 5 HandOrientations
- CLI-Einstieg: uv run python -m app.seeds.run

Tests (13/13 gruen gegen Postgres 16 + PostGIS 3.4):
- Migration-Smoke (Tabellen-Inventur, PostGIS, app_user-Rolle, RLS)
- Modell-Constraints (UNIQUE, CHECK, FK)
- Computed geom, updated_at-Trigger
- Seed-Idempotenz (zweiter Lauf 0 Inserts)
- Sync-DB-Fixture (psycopg) plus testcontainers-Fallback fuer Docker-CI
- ruff check, ruff format, mypy --strict alle clean

Doku:
- ADR-018 in docs/decisions.md (UUIDv7-Strategie, Trigger-Mechanik, RLS-Default-Policy, Seed-Strategie, Test-Infrastruktur)
- README-Setup um alembic upgrade head und Seed-Aufruf erweitert
- Phase-Badge auf M2-bereit aktualisiert (CLAUDE.md Abschnitt 6)
- CHANGELOG-Eintrag fuer M1

Fahrplan: M1 [ERLEDIGT] 2026-04-25