### PR TITLE
feat(m5a-1): Backend-Live-Endpoints + MapTiler-Tile-Proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,13 @@ HCMAP_ARGON2_PARALLELISM=1
 # HCMAP_BOOTSTRAP_PASSWORD=change-me-12-chars-or-more
 # HCMAP_BOOTSTRAP_NAME=Admin
 
+# --- Tile provider (M5a, ADR-022) ----------------------------------------
+# MapTiler Cloud API key. Server-side only — never exposed to the browser.
+# Empty string disables the tile proxy and returns 503 from /api/tiles/*.
+HCMAP_MAPTILER_API_KEY=
+# MapTiler style identifier; basic-v2 is on the free tier.
+HCMAP_MAPTILER_STYLE=basic-v2
+
 # --- Future variables (added with their respective milestones) -----------
-# HCMAP_MAPTILER_KEY=                # M6 — MapTiler tile/geocoding key
+# HCMAP_MAPTILER_GEOCODING_KEY=      # M6 — MapTiler geocoding (proxy)
 # HCMAP_SMTP_URL=                    # before M11 — password reset mail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ Bis zum ersten Go-Live (M11) bleibt das Projekt auf `0.0.0`.
 
 ### Added
 
+- **M5a.1 — Backend-Live-Endpoints + Tile-Proxy:** Sechs neue Backend-
+  Routen für die Live-Erfassung (Fahrplan §M5a, ADR-022/-024).
+  - `POST /api/events/start` setzt `started_at = now()`, fügt den Creator
+    automatisch als Participant hinzu und nimmt optional einen Recipient
+    direkt mit auf.
+  - `POST /api/events/{id}/end` und `POST /api/applications/{id}/end`
+    sind idempotent: ein zweiter Aufruf ändert `ended_at` nicht.
+  - `POST /api/events/{event_id}/applications/start` startet eine
+    Application mit `started_at = now()`, vergibt `sequence_no`
+    automatisch und füllt `performer_id`/`recipient_id` mit dem
+    eingeloggten User vor (Regel-002, Self-Bondage als Default).
+  - `POST /api/persons/quick` (admin + editor): On-the-fly-Person
+    mit `origin = on_the_fly`, `linkable = false` (Regel-004).
+  - `GET /api/tiles/{z}/{x}/{y}` als MapTiler-Proxy mit
+    server-seitigem API-Key, `Cache-Control: public, max-age=86400`,
+    Auth-Pflicht. Pfad-Parameter werden auf gültige Tile-Koordinaten
+    geprüft (`z` 0–22, `x`/`y` ≥ 0).
+  - 21 neue HTTP-Tests (test_events_live_api, test_applications_live_api,
+    test_persons_quick_api, test_tiles_proxy). Backend-Suite jetzt
+    74/74 grün gegen Postgres 16 + PostGIS 3.4.
+  - Neue ENV-Variablen `HCMAP_MAPTILER_API_KEY` und
+    `HCMAP_MAPTILER_STYLE` (Default `basic-v2`); leerer Key gibt 503.
+  - `httpx` aus den Dev- in die Runtime-Dependencies verschoben (für
+    den Tile-Proxy zur Laufzeit).
+  - ADR-024 dokumentiert die acht Detail-Entscheidungen
+    (Endpoint-Inventar, Idempotenz, Auto-Participant-Reuse, Tile-Proxy-
+    Mechanik, Default-Performer/-Recipient, ENV-Schalter, Tests, Scope-
+    Abgrenzung gegen M5a.2/.3/.4).
+- **M5a-Vorbereitung — ADR-022/-023:** ADR-022 zieht den minimalen
+  `LocationPicker` und den Tile-Proxy aus M6 in M5a vor; M6 reduziert
+  sich auf Marker-Liste, Clustering, Filter, URL-State und Geocoding.
+  ADR-023 legt das App-PIN-Hashing auf PBKDF2-SHA-256 (Web Crypto API,
+  600.000 Iterationen, 16-Byte-Salt) fest — keine neue Abhängigkeit.
+
 - **M4 — Frontend-Grundgerüst & Auth-Flow:** Login-, Logout- und
   geschütztes Layout produktiv. `lib/api.ts` als typisierter
   fetch-Wrapper mit `credentials: 'include'`, automatischer

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Selbst gehostetes, geo-referenziertes Logbuch für Fesselungs-Ereignisse einer geschlossenen Gruppe.**
 
 [![Status](https://img.shields.io/badge/status-mvp--phase--1-yellow)](./docs/fahrplan.md)
-[![Phase](https://img.shields.io/badge/phase-M5a--bereit-blue)](./docs/fahrplan.md#phasen-übersicht)
+[![Phase](https://img.shields.io/badge/phase-M5a.1--erledigt-blue)](./docs/fahrplan.md#phasen-übersicht)
 [![Version](https://img.shields.io/badge/version-v0.0.0-lightgrey)](./docs/project-context.md#1-kerndaten)
 [![Lizenz](https://img.shields.io/badge/lizenz-offen-red)](./docs/project-context.md#6-constraints-operationalisierbar)
 [![Docs](https://img.shields.io/badge/docs-deutsch-yellow)](./docs/project-context.md)
@@ -66,11 +66,11 @@ HC-Map ist ein **Full-Stack-Web-Projekt** (Mobile-First-PWA) zur strukturierten 
 
 | Phase | Stand |
 |---|---|
-| Phase 1 — MVP / Go-Live Pfad A | M0–M4 erledigt; M5a (Live-Modus) als nächstes |
+| Phase 1 — MVP / Go-Live Pfad A | M0–M4 erledigt, M5a.1 (Live-Endpoints + Tile-Proxy) erledigt; M5a.2 (Frontend Startseite/Suche/Export) als nächstes |
 | Phase 2 — Konsolidierung (Tileserver, Backups, Monitoring, Medien, Statistik) | offen |
 | Phase 3 — Pfad-B-Vorbereitung | nicht aktiviert |
 
-Der vollständige Meilensteinplan liegt in [`fahrplan.md`](./docs/fahrplan.md). M0–M4 sind abgeschlossen: Backend mit Schema/Migrations/RLS, Auth+CSRF+RBAC, Domain-API (Events, Applications, Persons, Catalog, Search, Throwbacks, Export), und ein Next.js-Frontend mit Login, Cookie-Session, geschütztem Layout (Sidebar Desktop / Bottom-Nav Mobile), Dark-Mode und Stub-Seiten für die kommenden Meilensteine. M5a (Live-Modus) folgt als nächstes.
+Der vollständige Meilensteinplan liegt in [`fahrplan.md`](./docs/fahrplan.md). M0–M4 sind abgeschlossen: Backend mit Schema/Migrations/RLS, Auth+CSRF+RBAC, Domain-API (Events, Applications, Persons, Catalog, Search, Throwbacks, Export), und ein Next.js-Frontend mit Login, Cookie-Session, geschütztem Layout (Sidebar Desktop / Bottom-Nav Mobile), Dark-Mode und Stub-Seiten für die kommenden Meilensteine. M5a.1 ergänzt sechs Backend-Live-Routen (events/start, events/{id}/end, applications/start, applications/{id}/end, persons/quick) und einen MapTiler-Tile-Proxy (`/api/tiles/{z}/{x}/{y}`). Frontend-Live-Modus folgt mit M5a.2/.3/.4.
 
 ---
 
@@ -113,7 +113,7 @@ hc-map/
 └── docs/           # Projekt-Dokumentation (siehe unten)
 ```
 
-M0–M4 sind umgesetzt: `backend/` enthält Schema, Migrations, RLS-Policies, Auth-Layer, Domain-API (44 Routen), Search/Throwbacks/Export; `frontend/` enthält Login-Flow, geschütztes Layout (Sidebar Desktop / Bottom-Nav Mobile), Dark-Mode und Stub-Seiten für Dashboard, Events, Karte, Admin und Profil; `docker/` startet Postgres+PostGIS, Backend und Frontend lokal. `ops/` und der eigene Tileserver folgen mit M10/M12.
+M0–M4 + M5a.1 sind umgesetzt: `backend/` enthält Schema, Migrations, RLS-Policies, Auth-Layer, Domain-API plus Live-Endpoints und MapTiler-Tile-Proxy (insgesamt 50 Routen), Search/Throwbacks/Export; `frontend/` enthält Login-Flow, geschütztes Layout (Sidebar Desktop / Bottom-Nav Mobile), Dark-Mode und Stub-Seiten für Dashboard, Events, Karte, Admin und Profil; `docker/` startet Postgres+PostGIS, Backend und Frontend lokal. `ops/` und der eigene Tileserver folgen mit M10/M12.
 
 ---
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -51,6 +51,16 @@ class Settings(BaseSettings):
     argon2_memory_cost: int = Field(default=19456)
     argon2_parallelism: int = Field(default=1)
 
+    # --- Tile provider (M5a, ADR-022) ----------------------------------
+    maptiler_api_key: str = Field(
+        default="",
+        description="MapTiler Cloud API key (server-side only). Empty disables tile proxy.",
+    )
+    maptiler_style: str = Field(
+        default="basic-v2",
+        description="MapTiler map style identifier used for tile URLs.",
+    )
+
 
 def get_settings() -> Settings:
     """Return a fresh Settings instance.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ from app.routes.events import router as events_router
 from app.routes.exports import router as exports_router
 from app.routes.persons import router as persons_router
 from app.routes.search import router as search_router
+from app.routes.tiles import router as tiles_router
 from app.security.csrf import CSRF_COOKIE, CSRFMiddleware
 
 
@@ -107,6 +108,7 @@ def create_app() -> FastAPI:
     app.include_router(hand_orientations_router, prefix="/api")
     app.include_router(search_router, prefix="/api")
     app.include_router(exports_router, prefix="/api")
+    app.include_router(tiles_router, prefix="/api")
 
     return app
 

--- a/backend/app/routes/applications.py
+++ b/backend/app/routes/applications.py
@@ -57,3 +57,20 @@ async def delete_application(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     await application_svc.delete_application(session, application)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/{application_id}/end",
+    response_model=ApplicationRead,
+    summary="Finish an application in Live mode (ended_at = now(), idempotent)",
+)
+async def end_application(
+    application_id: uuid.UUID,
+    session: AsyncSession = Depends(get_rls_session),
+) -> ApplicationRead:
+    application = await application_svc.get_application(session, application_id)
+    if application is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    await application_svc.end_application(session, application)
+    rt_ids = await application_svc.restraint_ids_for(session, application_id)
+    return ApplicationRead.model_validate({**application.__dict__, "restraint_type_ids": rt_ids})

--- a/backend/app/routes/events.py
+++ b/backend/app/routes/events.py
@@ -10,12 +10,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.routes import current_active_user
 from app.deps import get_rls_session
 from app.models.user import User
-from app.schemas.application import ApplicationCreate, ApplicationRead
+from app.schemas.application import (
+    ApplicationCreate,
+    ApplicationLiveStart,
+    ApplicationRead,
+)
 from app.schemas.common import Page
 from app.schemas.event import (
     EventCreate,
     EventDetail,
     EventListItem,
+    EventStart,
     EventUpdate,
 )
 from app.schemas.person import PersonRead
@@ -61,6 +66,43 @@ async def create_event(
     # The creator is implicitly a participant (so they can see their own event).
     await event_svc.add_participant(session, event.id, user.person_id)
     return await _build_detail(session, event.id, user)
+
+
+@router.post(
+    "/start",
+    response_model=EventDetail,
+    status_code=status.HTTP_201_CREATED,
+    summary="Start an event in Live mode (started_at = now())",
+)
+async def start_event(
+    payload: EventStart,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_rls_session),
+) -> EventDetail:
+    event = await event_svc.start_event(
+        session,
+        payload,
+        created_by=user.id,
+        creator_person_id=user.person_id,
+    )
+    return await _build_detail(session, event.id, user)
+
+
+@router.post(
+    "/{event_id}/end",
+    response_model=EventDetail,
+    summary="Finish an event in Live mode (ended_at = now(), idempotent)",
+)
+async def end_event(
+    event_id: uuid.UUID,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_rls_session),
+) -> EventDetail:
+    event = await event_svc.get_event(session, event_id)
+    if event is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    await event_svc.end_event(session, event)
+    return await _build_detail(session, event_id, user)
 
 
 @router.get(
@@ -162,6 +204,30 @@ async def create_application_for_event(
         created_by=user.id,
         role=user.role,
         strict=strict,
+    )
+    rt_ids = await application_svc.restraint_ids_for(session, application.id)
+    return ApplicationRead.model_validate({**application.__dict__, "restraint_type_ids": rt_ids})
+
+
+@router.post(
+    "/{event_id}/applications/start",
+    response_model=ApplicationRead,
+    status_code=status.HTTP_201_CREATED,
+    summary="Start an application in Live mode (started_at = now())",
+)
+async def start_application_for_event(
+    event_id: uuid.UUID,
+    payload: ApplicationLiveStart,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_rls_session),
+) -> ApplicationRead:
+    application = await application_svc.start_application(
+        session,
+        event_id=event_id,
+        payload=payload,
+        created_by=user.id,
+        requester_person_id=user.person_id,
+        role=user.role,
     )
     rt_ids = await application_svc.restraint_ids_for(session, application.id)
     return ApplicationRead.model_validate({**application.__dict__, "restraint_type_ids": rt_ids})

--- a/backend/app/routes/persons.py
+++ b/backend/app/routes/persons.py
@@ -7,11 +7,17 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth.routes import current_active_user
 from app.deps import get_rls_session, require_role
 from app.models.person import Person
 from app.models.user import User, UserRole
 from app.schemas.common import Page
-from app.schemas.person import PersonCreate, PersonRead, PersonUpdate
+from app.schemas.person import (
+    PersonCreate,
+    PersonQuickCreate,
+    PersonRead,
+    PersonUpdate,
+)
 from app.services import persons as person_svc
 
 router = APIRouter(prefix="/persons", tags=["persons"])
@@ -52,6 +58,26 @@ async def create_person(
     session: AsyncSession = Depends(get_rls_session),
 ) -> PersonRead:
     person = await person_svc.create_person(session, payload, created_by=user.id)
+    return PersonRead.model_validate(person)
+
+
+@router.post(
+    "/quick",
+    response_model=PersonRead,
+    status_code=status.HTTP_201_CREATED,
+    summary="On-the-fly person from Live mode (admin + editor, ADR-014)",
+)
+async def quick_create_person(
+    payload: PersonQuickCreate,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_rls_session),
+) -> PersonRead:
+    if user.role not in (UserRole.ADMIN, UserRole.EDITOR):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Insufficient role.",
+        )
+    person = await person_svc.quick_create_person(session, payload, created_by=user.id)
     return PersonRead.model_validate(person)
 
 

--- a/backend/app/routes/tiles.py
+++ b/backend/app/routes/tiles.py
@@ -1,0 +1,89 @@
+"""MapTiler tile proxy (ADR-022, ADR-024 §C).
+
+Front-ends MapLibre GL JS; the API key stays server-side. Authenticated
+users only — tiles are user-independent so no RLS is needed, but anonymous
+proxying would expose the upstream key to scraping.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from functools import lru_cache
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from fastapi.responses import StreamingResponse
+
+from app.auth.routes import current_active_user
+from app.config import get_settings
+from app.models.user import User
+
+router = APIRouter(prefix="/tiles", tags=["tiles"])
+
+_TILE_CACHE_SECONDS = 86_400
+_DEFAULT_TIMEOUT = httpx.Timeout(10.0, connect=5.0)
+
+
+@lru_cache(maxsize=1)
+def _http_client() -> httpx.AsyncClient:
+    """Process-singleton AsyncClient.
+
+    ``lru_cache`` keeps a single instance alive for the process. Tests
+    monkey-patch ``app.routes.tiles._http_client`` to inject a fake.
+    """
+    return httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT)
+
+
+def _build_upstream_url(z: int, x: int, y: int, *, api_key: str, style: str) -> str:
+    return f"https://api.maptiler.com/maps/{style}/{z}/{x}/{y}.png?key={api_key}"
+
+
+@router.get(
+    "/{z}/{x}/{y}",
+    summary="Proxy raster tile from MapTiler (auth required, server-side key)",
+)
+async def get_tile(
+    z: int = Path(..., ge=0, le=22),
+    x: int = Path(..., ge=0),
+    y: int = Path(..., ge=0),
+    _user: User = Depends(current_active_user),
+) -> StreamingResponse:
+    settings = get_settings()
+    if not settings.maptiler_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Tile provider not configured.",
+        )
+
+    url = _build_upstream_url(
+        z,
+        x,
+        y,
+        api_key=settings.maptiler_api_key,
+        style=settings.maptiler_style,
+    )
+    client = _http_client()
+    try:
+        upstream = await client.get(url)
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Tile upstream unreachable.",
+        ) from exc
+
+    if upstream.status_code >= 400:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Tile upstream returned error.",
+        )
+
+    media_type = upstream.headers.get("content-type", "image/png")
+
+    async def _iter() -> AsyncIterator[bytes]:
+        yield upstream.content
+
+    return StreamingResponse(
+        _iter(),
+        media_type=media_type,
+        headers={"Cache-Control": f"public, max-age={_TILE_CACHE_SECONDS}"},
+    )

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -30,6 +30,24 @@ class ApplicationCreate(ApplicationBase):
     restraint_type_ids: list[uuid.UUID] = Field(default_factory=list)
 
 
+class ApplicationLiveStart(BaseModel):
+    """Body for ``POST /api/events/{event_id}/applications/start`` (ADR-024 §B).
+
+    ``started_at`` is assigned server-side. ``performer_id`` defaults to
+    the requesting user's ``person_id`` if omitted (Regel-002).
+    ``recipient_id`` defaults to the same person (self-bondage) if
+    omitted; the UI is expected to pass the chosen recipient explicitly.
+    """
+
+    performer_id: uuid.UUID | None = None
+    recipient_id: uuid.UUID | None = None
+    arm_position_id: uuid.UUID | None = None
+    hand_position_id: uuid.UUID | None = None
+    hand_orientation_id: uuid.UUID | None = None
+    note: str | None = None
+    restraint_type_ids: list[uuid.UUID] = Field(default_factory=list)
+
+
 class ApplicationUpdate(BaseModel):
     performer_id: uuid.UUID | None = None
     recipient_id: uuid.UUID | None = None

--- a/backend/app/schemas/event.py
+++ b/backend/app/schemas/event.py
@@ -25,6 +25,21 @@ class EventCreate(EventBase):
     """Body for ``POST /api/events`` (non-Live mode, see ADR-020 §A)."""
 
 
+class EventStart(BaseModel):
+    """Body for ``POST /api/events/start`` (Live-mode, see ADR-024 §B).
+
+    ``started_at`` is assigned server-side as ``now()``. Optionally a
+    recipient person can be passed in — the server then adds it as
+    ``EventParticipant`` so the UI can pre-fill subsequent live-applications.
+    """
+
+    lat: Decimal = Field(..., ge=Decimal("-90"), le=Decimal("90"))
+    lon: Decimal = Field(..., ge=Decimal("-180"), le=Decimal("180"))
+    recipient_id: uuid.UUID | None = None
+    reveal_participants: bool = False
+    note: str | None = None
+
+
 class EventUpdate(BaseModel):
     started_at: datetime | None = None
     ended_at: datetime | None = None

--- a/backend/app/schemas/person.py
+++ b/backend/app/schemas/person.py
@@ -31,6 +31,17 @@ class PersonCreate(BaseModel):
     linkable: bool = False
 
 
+class PersonQuickCreate(BaseModel):
+    """Body for ``POST /api/persons/quick`` (Live-mode, ADR-014 + ADR-024).
+
+    Restricted to ``name`` and optional ``alias``. The server forces
+    ``origin = on_the_fly`` and ``linkable = false`` (Regel-004).
+    """
+
+    name: str = Field(min_length=1, max_length=200)
+    alias: str | None = Field(default=None, max_length=200)
+
+
 class PersonUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=200)
     alias: str | None = Field(default=None, max_length=200)

--- a/backend/app/services/applications.py
+++ b/backend/app/services/applications.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Sequence
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import HTTPException, status
@@ -28,7 +29,11 @@ from app.models.catalog import (
 )
 from app.models.event import EventParticipant
 from app.models.user import UserRole
-from app.schemas.application import ApplicationCreate, ApplicationUpdate
+from app.schemas.application import (
+    ApplicationCreate,
+    ApplicationLiveStart,
+    ApplicationUpdate,
+)
 
 
 async def _ensure_approved_catalog(
@@ -132,6 +137,74 @@ async def create_application(
         session.add(ApplicationRestraint(application_id=application.id, restraint_type_id=rt_id))
     await session.flush()
     await session.refresh(application)
+    return application
+
+
+async def start_application(
+    session: AsyncSession,
+    *,
+    event_id: uuid.UUID,
+    payload: ApplicationLiveStart,
+    created_by: uuid.UUID,
+    requester_person_id: uuid.UUID,
+    role: UserRole,
+) -> Application:
+    """Create a Live-mode application (ADR-024 §B, fahrplan §M5a).
+
+    ``started_at`` is set to ``now()``. ``performer_id`` defaults to the
+    requester's person (Regel-002); ``recipient_id`` defaults to the
+    same person (self-bondage) if not supplied — UI is expected to pass
+    the chosen recipient explicitly.
+    """
+    performer_id = payload.performer_id or requester_person_id
+    recipient_id = payload.recipient_id or requester_person_id
+
+    await _ensure_approved_catalog(
+        session,
+        role=role,
+        arm_position_id=payload.arm_position_id,
+        hand_position_id=payload.hand_position_id,
+        hand_orientation_id=payload.hand_orientation_id,
+        restraint_type_ids=payload.restraint_type_ids,
+    )
+    seq = await _next_sequence_no(session, event_id)
+    application = Application(
+        event_id=event_id,
+        performer_id=performer_id,
+        recipient_id=recipient_id,
+        arm_position_id=payload.arm_position_id,
+        hand_position_id=payload.hand_position_id,
+        hand_orientation_id=payload.hand_orientation_id,
+        sequence_no=seq,
+        started_at=datetime.now(tz=UTC),
+        ended_at=None,
+        note=payload.note,
+        created_by=created_by,
+    )
+    session.add(application)
+    await session.flush()
+
+    # Auto-Participant (ADR-012)
+    await _ensure_participant(session, event_id, performer_id)
+    if recipient_id != performer_id:
+        await _ensure_participant(session, event_id, recipient_id)
+
+    for rt_id in payload.restraint_type_ids:
+        session.add(ApplicationRestraint(application_id=application.id, restraint_type_id=rt_id))
+    await session.flush()
+    await session.refresh(application)
+    return application
+
+
+async def end_application(
+    session: AsyncSession,
+    application: Application,
+) -> Application:
+    """Set ``ended_at = now()`` if not already set (idempotent)."""
+    if application.ended_at is None:
+        application.ended_at = datetime.now(tz=UTC)
+        await session.flush()
+        await session.refresh(application)
     return application
 
 

--- a/backend/app/services/events.py
+++ b/backend/app/services/events.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Sequence
+from datetime import UTC, datetime
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.event import Event, EventParticipant
 from app.models.person import Person
-from app.schemas.event import EventCreate, EventUpdate
+from app.schemas.event import EventCreate, EventStart, EventUpdate
 
 
 async def list_events(
@@ -78,6 +79,47 @@ async def update_event(
 async def delete_event(session: AsyncSession, event: Event) -> None:
     await session.delete(event)
     await session.flush()
+
+
+async def start_event(
+    session: AsyncSession,
+    payload: EventStart,
+    *,
+    created_by: uuid.UUID,
+    creator_person_id: uuid.UUID,
+) -> Event:
+    """Create a Live-mode event with ``started_at = now()`` (ADR-024 §B).
+
+    The creator is implicitly added as a participant. If a recipient is
+    supplied, it is added as a second participant so subsequent
+    live-applications can default to it.
+    """
+    event = Event(
+        started_at=datetime.now(tz=UTC),
+        ended_at=None,
+        lat=payload.lat,
+        lon=payload.lon,
+        reveal_participants=payload.reveal_participants,
+        note=payload.note,
+        created_by=created_by,
+    )
+    session.add(event)
+    await session.flush()
+    await session.refresh(event)
+
+    await add_participant(session, event.id, creator_person_id)
+    if payload.recipient_id and payload.recipient_id != creator_person_id:
+        await add_participant(session, event.id, payload.recipient_id)
+    return event
+
+
+async def end_event(session: AsyncSession, event: Event) -> Event:
+    """Set ``ended_at = now()`` if not already set (idempotent)."""
+    if event.ended_at is None:
+        event.ended_at = datetime.now(tz=UTC)
+        await session.flush()
+        await session.refresh(event)
+    return event
 
 
 async def list_participants(session: AsyncSession, event_id: uuid.UUID) -> Sequence[Person]:

--- a/backend/app/services/persons.py
+++ b/backend/app/services/persons.py
@@ -9,8 +9,8 @@ from datetime import UTC, datetime
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.person import Person
-from app.schemas.person import PersonCreate, PersonUpdate
+from app.models.person import Person, PersonOrigin
+from app.schemas.person import PersonCreate, PersonQuickCreate, PersonUpdate
 
 
 async def list_persons(
@@ -46,6 +46,29 @@ async def create_person(
         alias=payload.alias,
         note=payload.note,
         linkable=payload.linkable,
+        created_by=created_by,
+    )
+    session.add(person)
+    await session.flush()
+    await session.refresh(person)
+    return person
+
+
+async def quick_create_person(
+    session: AsyncSession,
+    payload: PersonQuickCreate,
+    *,
+    created_by: uuid.UUID,
+) -> Person:
+    """Spontaneous on-the-fly person from the live capture flow.
+
+    Forces ``origin = on_the_fly`` and ``linkable = false`` (Regel-004).
+    """
+    person = Person(
+        name=payload.name,
+        alias=payload.alias,
+        origin=PersonOrigin.ON_THE_FLY,
+        linkable=False,
         created_by=created_by,
     )
     session.add(person)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pyjwt>=2.10,<3",
     "email-validator>=2.2,<3",
     "openlocationcode>=1.0,<2",
+    "httpx>=0.27,<0.28",
 ]
 
 [dependency-groups]
@@ -29,7 +30,6 @@ dev = [
     "mypy>=1.13,<2",
     "pytest>=8.3,<9",
     "pytest-asyncio>=0.24,<0.25",
-    "httpx>=0.27,<0.28",
     "testcontainers[postgresql]>=4.8,<5",
 ]
 

--- a/backend/tests/test_applications_live_api.py
+++ b/backend/tests/test_applications_live_api.py
@@ -1,0 +1,168 @@
+"""HTTP tests for the Applications Live-mode endpoints (M5a.1)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from app.models.user import UserRole
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from tests.api_helpers import login_as, post_with_csrf
+
+
+@pytest.fixture(autouse=True)
+async def _clean(async_session_factory: async_sessionmaker[AsyncSession]):
+    yield
+    async with async_session_factory() as session, session.begin():
+        await session.execute(text("DELETE FROM event_participant"))
+        await session.execute(text("DELETE FROM application_restraint"))
+        await session.execute(text("DELETE FROM application"))
+        await session.execute(text("DELETE FROM event"))
+
+
+async def _make_person(async_session_factory: async_sessionmaker[AsyncSession], name: str) -> str:
+    from app.models.base import uuid7
+
+    pid = uuid7()
+    async with async_session_factory() as session, session.begin():
+        await session.execute(
+            text("INSERT INTO person (id, name) VALUES (:id, :n)"),
+            {"id": pid, "n": name},
+        )
+    return str(pid)
+
+
+async def _start_event(client: AsyncClient, csrf: str) -> str:
+    resp = await post_with_csrf(
+        client,
+        csrf,
+        "/api/events/start",
+        json={"lat": "0", "lon": "0"},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def test_start_application_sets_started_at_and_sequence_no(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    user, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    event_id = await _start_event(client, csrf)
+    recipient_id = await _make_person(async_session_factory, "AppRecipient")
+    before = datetime.now(tz=UTC)
+    resp = await post_with_csrf(
+        client,
+        csrf,
+        f"/api/events/{event_id}/applications/start",
+        json={"recipient_id": recipient_id},
+    )
+    after = datetime.now(tz=UTC)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["sequence_no"] == 1
+    assert body["ended_at"] is None
+    started = datetime.fromisoformat(body["started_at"])
+    assert before <= started <= after
+    # Default performer is the requesting user (Regel-002).
+    assert body["performer_id"] == str(user.person_id)
+    assert body["recipient_id"] == recipient_id
+
+
+async def test_start_application_defaults_to_self_bondage_without_recipient(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    user, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    event_id = await _start_event(client, csrf)
+    resp = await post_with_csrf(
+        client,
+        csrf,
+        f"/api/events/{event_id}/applications/start",
+        json={},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["performer_id"] == str(user.person_id)
+    assert body["recipient_id"] == str(user.person_id)
+
+
+async def test_start_application_increments_sequence(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    event_id = await _start_event(client, csrf)
+    first = await post_with_csrf(
+        client,
+        csrf,
+        f"/api/events/{event_id}/applications/start",
+        json={},
+    )
+    second = await post_with_csrf(
+        client,
+        csrf,
+        f"/api/events/{event_id}/applications/start",
+        json={},
+    )
+    assert first.json()["sequence_no"] == 1
+    assert second.json()["sequence_no"] == 2
+
+
+async def test_end_application_sets_ended_at(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    event_id = await _start_event(client, csrf)
+    start = await post_with_csrf(
+        client,
+        csrf,
+        f"/api/events/{event_id}/applications/start",
+        json={},
+    )
+    app_id = start.json()["id"]
+    end = await post_with_csrf(client, csrf, f"/api/applications/{app_id}/end")
+    assert end.status_code == 200, end.text
+    assert end.json()["ended_at"] is not None
+
+
+async def test_end_application_idempotent(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    event_id = await _start_event(client, csrf)
+    start = await post_with_csrf(
+        client,
+        csrf,
+        f"/api/events/{event_id}/applications/start",
+        json={},
+    )
+    app_id = start.json()["id"]
+    first = await post_with_csrf(client, csrf, f"/api/applications/{app_id}/end")
+    second = await post_with_csrf(client, csrf, f"/api/applications/{app_id}/end")
+    assert first.json()["ended_at"] == second.json()["ended_at"]
+
+
+async def test_auto_participant_when_recipient_supplied(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """ADR-012: recipient becomes participant of the event."""
+    user, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    event_id = await _start_event(client, csrf)
+    recipient_id = await _make_person(async_session_factory, "AutoPart")
+    await post_with_csrf(
+        client,
+        csrf,
+        f"/api/events/{event_id}/applications/start",
+        json={"recipient_id": recipient_id},
+    )
+    detail = await client.get(f"/api/events/{event_id}")
+    pids = {p["id"] for p in detail.json()["participants"]}
+    assert str(user.person_id) in pids
+    assert recipient_id in pids

--- a/backend/tests/test_events_live_api.py
+++ b/backend/tests/test_events_live_api.py
@@ -1,0 +1,126 @@
+"""HTTP tests for the Events Live-mode endpoints (M5a.1)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from app.models.user import UserRole
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from tests.api_helpers import login_as, post_with_csrf
+
+
+@pytest.fixture(autouse=True)
+async def _clean(async_session_factory: async_sessionmaker[AsyncSession]):
+    yield
+    async with async_session_factory() as session, session.begin():
+        await session.execute(text("DELETE FROM event_participant"))
+        await session.execute(text("DELETE FROM application_restraint"))
+        await session.execute(text("DELETE FROM application"))
+        await session.execute(text("DELETE FROM event"))
+
+
+async def _make_person(async_session_factory: async_sessionmaker[AsyncSession], name: str) -> str:
+    from app.models.base import uuid7
+
+    pid = uuid7()
+    async with async_session_factory() as session, session.begin():
+        await session.execute(
+            text("INSERT INTO person (id, name) VALUES (:id, :n)"),
+            {"id": pid, "n": name},
+        )
+    return str(pid)
+
+
+async def test_start_event_assigns_started_at_now_and_no_ended_at(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    user, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    before = datetime.now(tz=UTC)
+    resp = await post_with_csrf(
+        client,
+        csrf,
+        "/api/events/start",
+        json={"lat": "52.520008", "lon": "13.404954"},
+    )
+    after = datetime.now(tz=UTC)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["ended_at"] is None
+    started = datetime.fromisoformat(body["started_at"])
+    assert before <= started <= after
+    # Creator is automatically a participant.
+    participant_ids = {p["id"] for p in body["participants"]}
+    assert str(user.person_id) in participant_ids
+
+
+async def test_start_event_with_recipient_adds_both_participants(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    user, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    recipient_id = await _make_person(async_session_factory, "LiveRecipient")
+    resp = await post_with_csrf(
+        client,
+        csrf,
+        "/api/events/start",
+        json={"lat": "0", "lon": "0", "recipient_id": recipient_id},
+    )
+    assert resp.status_code == 201, resp.text
+    participant_ids = {p["id"] for p in resp.json()["participants"]}
+    assert str(user.person_id) in participant_ids
+    assert recipient_id in participant_ids
+
+
+async def test_end_event_sets_ended_at(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    start = await post_with_csrf(
+        client,
+        csrf,
+        "/api/events/start",
+        json={"lat": "0", "lon": "0"},
+    )
+    event_id = start.json()["id"]
+    end = await post_with_csrf(client, csrf, f"/api/events/{event_id}/end")
+    assert end.status_code == 200, end.text
+    assert end.json()["ended_at"] is not None
+
+
+async def test_end_event_idempotent(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A second end call must not advance ``ended_at``."""
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    start = await post_with_csrf(
+        client,
+        csrf,
+        "/api/events/start",
+        json={"lat": "0", "lon": "0"},
+    )
+    event_id = start.json()["id"]
+    first = await post_with_csrf(client, csrf, f"/api/events/{event_id}/end")
+    second = await post_with_csrf(client, csrf, f"/api/events/{event_id}/end")
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["ended_at"] == second.json()["ended_at"]
+
+
+async def test_end_event_unknown_id_returns_404(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    resp = await post_with_csrf(
+        client,
+        csrf,
+        "/api/events/00000000-0000-0000-0000-000000000000/end",
+    )
+    assert resp.status_code == 404

--- a/backend/tests/test_persons_quick_api.py
+++ b/backend/tests/test_persons_quick_api.py
@@ -1,0 +1,88 @@
+"""HTTP tests for the on-the-fly person endpoint (M5a.1, ADR-014)."""
+
+from __future__ import annotations
+
+import pytest
+from app.models.user import UserRole
+from httpx import AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from tests.api_helpers import login_as, post_with_csrf
+
+
+@pytest.fixture(autouse=True)
+async def _clean(async_session_factory: async_sessionmaker[AsyncSession]):
+    yield
+    async with async_session_factory() as session, session.begin():
+        await session.execute(text("DELETE FROM event_participant"))
+        await session.execute(text("DELETE FROM application_restraint"))
+        await session.execute(text("DELETE FROM application"))
+        await session.execute(text("DELETE FROM event"))
+
+
+async def test_admin_can_quick_create_person(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    resp = await post_with_csrf(
+        client,
+        csrf,
+        "/api/persons/quick",
+        json={"name": "Admin-OnTheFly"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["name"] == "Admin-OnTheFly"
+    assert body["origin"] == "on_the_fly"
+    assert body["linkable"] is False
+
+
+async def test_editor_can_quick_create_person(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.EDITOR)
+    resp = await post_with_csrf(
+        client,
+        csrf,
+        "/api/persons/quick",
+        json={"name": "Editor-OnTheFly", "alias": "EOF"},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["alias"] == "EOF"
+    assert body["origin"] == "on_the_fly"
+    assert body["linkable"] is False
+
+
+async def test_viewer_blocked_from_quick_create(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.VIEWER)
+    resp = await post_with_csrf(
+        client,
+        csrf,
+        "/api/persons/quick",
+        json={"name": "Forbidden"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_quick_create_ignores_attempts_to_set_linkable(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Regel-004: linkable=false is server-enforced; extra body fields are
+    ignored by the schema."""
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.EDITOR)
+    resp = await post_with_csrf(
+        client,
+        csrf,
+        "/api/persons/quick",
+        json={"name": "TryLink", "linkable": True},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["linkable"] is False

--- a/backend/tests/test_tiles_proxy.py
+++ b/backend/tests/test_tiles_proxy.py
@@ -1,0 +1,122 @@
+"""HTTP tests for the MapTiler tile proxy (M5a.1, ADR-022)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+from app.models.user import UserRole
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from tests.api_helpers import login_as
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, content: bytes, content_type: str) -> None:
+        self.status_code = status_code
+        self.content = content
+        self.headers: dict[str, str] = {"content-type": content_type}
+
+
+class _FakeAsyncClient:
+    """Stand-in for httpx.AsyncClient in tests; records calls."""
+
+    def __init__(self, *, response: _FakeResponse | None = None, raise_exc: bool = False) -> None:
+        self._response = response
+        self._raise_exc = raise_exc
+        self.last_url: str | None = None
+
+    async def get(self, url: str, **kwargs: Any) -> _FakeResponse:
+        self.last_url = url
+        if self._raise_exc:
+            raise httpx.ConnectError("simulated network failure")
+        assert self._response is not None
+        return self._response
+
+
+async def test_anonymous_request_blocked(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HCMAP_MAPTILER_API_KEY", "test-key")
+    resp = await client.get("/api/tiles/3/4/5")
+    assert resp.status_code == 401
+
+
+async def test_missing_api_key_returns_503(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HCMAP_MAPTILER_API_KEY", "")
+    await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    resp = await client.get("/api/tiles/3/4/5")
+    assert resp.status_code == 503
+
+
+async def test_successful_tile_returns_image_with_cache_header(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HCMAP_MAPTILER_API_KEY", "test-key")
+    monkeypatch.setenv("HCMAP_MAPTILER_STYLE", "basic-v2")
+    fake = _FakeAsyncClient(
+        response=_FakeResponse(200, b"\x89PNG\r\n\x1a\n--fake--", "image/png"),
+    )
+    monkeypatch.setattr("app.routes.tiles._http_client", lambda: fake)
+
+    await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    resp = await client.get("/api/tiles/3/4/5")
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"] == "image/png"
+    assert "max-age=86400" in resp.headers["cache-control"]
+    assert resp.content.startswith(b"\x89PNG")
+    assert fake.last_url is not None
+    assert "/maps/basic-v2/3/4/5.png" in fake.last_url
+    assert "key=test-key" in fake.last_url
+
+
+async def test_upstream_network_error_returns_502(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HCMAP_MAPTILER_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "app.routes.tiles._http_client",
+        lambda: _FakeAsyncClient(raise_exc=True),
+    )
+    await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    resp = await client.get("/api/tiles/3/4/5")
+    assert resp.status_code == 502
+
+
+async def test_upstream_status_4xx_returns_502(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HCMAP_MAPTILER_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "app.routes.tiles._http_client",
+        lambda: _FakeAsyncClient(
+            response=_FakeResponse(403, b"forbidden", "text/plain"),
+        ),
+    )
+    await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    resp = await client.get("/api/tiles/3/4/5")
+    assert resp.status_code == 502
+
+
+async def test_zoom_out_of_range_rejected(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HCMAP_MAPTILER_API_KEY", "test-key")
+    await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    resp = await client.get("/api/tiles/99/0/0")
+    assert resp.status_code == 422

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -377,6 +377,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastapi-users", extra = ["sqlalchemy"] },
     { name = "geoalchemy2" },
+    { name = "httpx" },
     { name = "openlocationcode" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
@@ -390,7 +391,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -407,6 +407,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115,<0.116" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=14,<15" },
     { name = "geoalchemy2", specifier = ">=0.15,<0.16" },
+    { name = "httpx", specifier = ">=0.27,<0.28" },
     { name = "openlocationcode", specifier = ">=1.0,<2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2,<4" },
     { name = "pydantic", specifier = ">=2.9,<3" },
@@ -420,7 +421,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.27,<0.28" },
     { name = "mypy", specifier = ">=1.13,<2" },
     { name = "pytest", specifier = ">=8.3,<9" },
     { name = "pytest-asyncio", specifier = ">=0.24,<0.25" },

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -49,6 +49,7 @@ Status-Legende:
 | ADR-021 | Implementierungsstrategie M4 (Frontend-Grundgerüst, Auth-Flow)  | Accepted | 2026-04-25  |
 | ADR-022 | LocationPicker und Tile-Proxy in M5a vorgezogen                 | Accepted | 2026-04-26  |
 | ADR-023 | App-PIN-Hashing clientseitig via PBKDF2 (Web Crypto API)        | Accepted | 2026-04-26  |
+| ADR-024 | Implementierungsstrategie M5a.1 (Live-Endpoints + Tile-Proxy)   | Accepted | 2026-04-26  |
 
 ---
 
@@ -1559,6 +1560,146 @@ oder die IndexedDB. Letzteres ist Job von Geräte-Sperre und Auth-System
   die Offline-Tauglichkeit (RxDB im Funkloch, ADR-017) und macht aus
   der UI-Sperre einen vollwertigen zweiten Auth-Faktor — größere
   Architekturwirkung als gewünscht.
+
+---
+
+## ADR-024 — Implementierungsstrategie M5a.1 (Live-Endpoints + Tile-Proxy)
+
+**Status:** Akzeptiert (2026-04-26)
+
+**Kontext:** M3 lieferte das generische Domain-CRUD; die fünf Live-Modus-
+Endpunkte (`POST /api/events/start`, `POST /api/events/{id}/end`,
+`POST /api/events/{event_id}/applications/start`,
+`POST /api/applications/{id}/end`, `POST /api/persons/quick`) wurden
+laut ADR-020 §A1 bewusst in M5a verschoben. Mit ADR-022 kommt zusätzlich
+der Tile-Proxy `GET /api/tiles/{z}/{x}/{y}` in den M5a-Scope. M5a.1 setzt
+dieses Backend-Paket um.
+
+**Entscheidungen:**
+
+1. **Endpoint-Inventar (A):** Sechs Routen, alle unter `/api/`:
+   - `POST /api/events/start` (Live-Event-Anlage, ADR-011)
+   - `POST /api/events/{id}/end` (Live-Event-Beendigung, idempotent)
+   - `POST /api/events/{event_id}/applications/start` (Live-Application-
+     Anlage, ADR-011 + ADR-012)
+   - `POST /api/applications/{id}/end` (Live-Application-Beendigung,
+     idempotent)
+   - `POST /api/persons/quick` (On-the-fly-Person, ADR-014)
+   - `GET /api/tiles/{z}/{x}/{y}` (MapTiler-Proxy, ADR-022)
+
+2. **Idempotenz der End-Endpoints (B):** `end_event` und
+   `end_application` setzen `ended_at = now()` nur, wenn das Feld noch
+   `NULL` ist. Ein zweiter Aufruf liefert denselben Datensatz mit
+   demselben `ended_at` zurück. Damit überlebt der Live-Modus
+   doppelte Klicks, Reconnect-Retries und RxDB-Replay (ab M5b) ohne
+   Sonderbehandlung. Verworfen wurde 409-Conflict bei zweitem End-Call:
+   bricht idempotente HTTP-Semantik und zwingt Frontend zu Status-
+   Tracking, das es nicht braucht.
+
+3. **Auto-Participant-Wiederverwendung (C):** `start_event` ruft den in
+   M3 etablierten `add_participant` auf, um den Creator und (falls
+   gesetzt) den Recipient als `EventParticipant` zu hinterlegen.
+   `start_application` nutzt den vorhandenen `_ensure_participant` aus
+   `services/applications.py`. Keine neue DB-Logik, kein neuer Trigger.
+   Verworfen wurde eine Trigger-basierte Variante (zu schwer testbar,
+   Regel-003 hängt an der Service-Schicht).
+
+4. **Default-Performer/Recipient für Live-Applications (D):**
+   - `performer_id` fehlt → `requester_person_id` (Regel-002).
+   - `recipient_id` fehlt → `requester_person_id` (Self-Bondage als
+     Default; UI ist verantwortlich, den gewählten Recipient explizit
+     zu schicken).
+   Diese Defaults gelten **nur** für `applications/start`, nicht für
+   `applications` (M3-Pfad), weil dort beide Felder Pflicht sind.
+   Bewusst keine Pflicht-Validierung von `recipient_id ≠ performer_id`
+   im Live-Pfad — entspricht ADR-020 §I (Self-Bondage erlaubt).
+
+5. **Recipient-Vermerk auf Event (E):** `EventStart` akzeptiert ein
+   optionales `recipient_id`-Feld. Wird es übergeben, fügt `start_event`
+   die Person als Participant hinzu. **Das Event-Schema bleibt
+   unverändert** — kein neues `recipient_id`-Feld auf `event`. Die UI
+   merkt sich den ausgewählten Recipient im Client-State und füllt ihn
+   in `applications/start` ein. Verworfen wurde eine `event.recipient_id`-
+   Spalte (Schema-Migration für ein UI-Convenience-Feld; widerspricht
+   ADR-020 §A1, weil das Datenmodell rein per-Application ist).
+
+6. **Tile-Proxy-Mechanik (F, ADR-022):**
+   - Auth: `current_active_user`-Dependency. RLS-Session nicht nötig
+     (Tiles sind nutzer-unabhängig).
+   - Pfad-Parameter werden auf gültige Tile-Koordinaten validiert:
+     `z` ∈ [0, 22], `x`/`y` ≥ 0.
+   - Upstream-URL aus `MAPTILER_STYLE` und `MAPTILER_API_KEY`
+     aufgebaut: `https://api.maptiler.com/maps/{style}/{z}/{x}/{y}.png?key={key}`.
+   - HTTP-Client: `httpx.AsyncClient` als Prozess-Singleton via
+     `lru_cache(maxsize=1)`, Timeout 10 s (Connect 5 s).
+   - Antwort: `StreamingResponse` mit upstream-Content-Type und
+     `Cache-Control: public, max-age=86400` (24 h).
+   - Fehler-Mapping: Netzwerk-Exception → 502; Upstream-Status ≥ 400 →
+     502 (kein Detail-Leak des Upstream-Statuses); leerer API-Key → 503.
+
+7. **httpx als Runtime-Dependency (G):** `httpx` war bislang nur Dev-
+   Abhängigkeit (Tests). Für den Tile-Proxy zur Laufzeit wird es in
+   `[project.dependencies]` aufgenommen. Lizenz BSD-3-Clause, kompatibel
+   mit der Allow-List in `project-context.md` §6 — keine separate
+   Lizenz-Freigabe nötig.
+
+8. **CSRF und Whitelist (H):** Alle fünf Live-Endpunkte sind
+   state-changing (POST) und werden vom CSRF-Middleware-Schutz
+   abgedeckt. Der Tile-Proxy ist ein GET und durchläuft die
+   `_SAFE_METHODS`-Ausnahme automatisch. Kein Whitelist-Eintrag nötig.
+
+9. **Tests (I):** 21 neue HTTP-Tests gegen Postgres 16 + PostGIS 3.4:
+   - `test_events_live_api.py` (5): start setzt `started_at` ±2 s,
+     start mit Recipient fügt beide als Participant hinzu, end setzt
+     `ended_at`, end ist idempotent, end auf unbekannte ID → 404.
+   - `test_applications_live_api.py` (6): start setzt `started_at` und
+     `sequence_no=1`, Default-Self-Bondage ohne Recipient, sequence_no
+     inkrementiert, end setzt `ended_at`, end idempotent,
+     Auto-Participant funktioniert.
+   - `test_persons_quick_api.py` (4): admin und editor erlaubt, viewer
+     blockiert (403), `linkable=true` im Body wird ignoriert.
+   - `test_tiles_proxy.py` (6): anonym blockiert (401), kein Key → 503,
+     Erfolgsfall mit Cache-Header und Upstream-URL-Verifikation,
+     Netzwerk-Fehler → 502, Upstream-4xx → 502, Zoom out of range
+     → 422.
+   Backend-Suite: 53 → 74 Tests, alles grün. ruff und ruff format clean.
+
+10. **Scope-Abgrenzung gegen M5a.2/.3/.4 (J):**
+    - **M5a.1 (dieser ADR):** Backend-Live-Endpoints + Tile-Proxy +
+      Tests + ENV.
+    - **M5a.2:** Frontend Startseite, Suche, Export-UI — konsumiert
+      ausschließlich M3-Endpoints, keine Backend-Änderungen.
+    - **M5a.3:** Frontend Live-Modus + LocationPickerMap — konsumiert
+      die hier gebauten Endpoints + den Tile-Proxy.
+    - **M5a.4:** App-PIN-Sperre nach ADR-023, querliegend zu allen
+      Frontend-Routen, kein Backend-Anteil.
+    Trennung minimiert PR-Größe und macht Reviews abnehmbar.
+
+**Konsequenzen:**
+
+- Live-Modus-Endpoints sind ab M5a.1 produktiv. Frontend kann ohne
+  weitere Backend-Arbeit anbinden.
+- Tile-Proxy ist betriebsbereit, **aber inaktiv ohne Key** — leerer
+  `HCMAP_MAPTILER_API_KEY` liefert 503. Das ist gewollt: Vor M11 muss
+  im Deployment der Key konfiguriert werden, sonst zeigt das Frontend
+  „Karte nicht verfügbar".
+- mypy meldet weiterhin den vorbestehenden M2-Fehler in
+  `app/auth/routes.py:20` (TypeVar `models.UP` vs. eigenes User). Der
+  Fehler ist nicht durch M5a.1 verursacht und liegt im M2-Modul; eine
+  Korrektur wäre Scope-Erweiterung in fremde Modulgrenze (CLAUDE.md
+  §6 + §8). Wird separat aufzulösen sein, sobald jemand am Auth-Modul
+  arbeitet.
+
+**Verworfene Alternativen:**
+
+- B2 (409-Conflict bei doppeltem End-Call): bricht HTTP-Idempotenz.
+- C2 (DB-Trigger für Auto-Participant): widerspricht ADR-020 §E2.
+- E2 (`event.recipient_id`-Spalte): Schema-Migration für UI-Komfort
+  ohne Datenmodell-Bedarf.
+- F2 (Tile-Proxy ohne lru_cache): jede Anfrage mit neuem
+  `httpx.AsyncClient`-Instance — Verbindungs-Pool-Verlust.
+- G2 (httpx in dev-Group lassen + Production-Imports): bricht Runtime
+  in der Produktion.
 
 ---
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -47,6 +47,8 @@ Status-Legende:
 | ADR-019 | Implementierungsstrategie M2 (Auth, CSRF, RLS-Mechanik)         | Accepted | 2026-04-25  |
 | ADR-020 | Implementierungsstrategie M3 (Domain-API, Search, Export)       | Accepted | 2026-04-25  |
 | ADR-021 | Implementierungsstrategie M4 (Frontend-Grundgerüst, Auth-Flow)  | Accepted | 2026-04-25  |
+| ADR-022 | LocationPicker und Tile-Proxy in M5a vorgezogen                 | Accepted | 2026-04-26  |
+| ADR-023 | App-PIN-Hashing clientseitig via PBKDF2 (Web Crypto API)        | Accepted | 2026-04-26  |
 
 ---
 
@@ -1364,6 +1366,199 @@ Verhalten; für die Browser-Seite werden elf Detail-Entscheidungen fixiert.
 - F2 (Drawer/Hamburger): kollidiert mit ADR-011 — Live-Modus braucht
   schnellen Tab-Wechsel auf Mobile.
 - G2 (eigene Tailwind-Class-Strategie): Hydration-Risiko, mehr Code.
+
+---
+
+## ADR-022 — LocationPicker und Tile-Proxy in M5a vorgezogen
+
+**Status:** Akzeptiert (2026-04-26)
+
+**Kontext:** M5a verlangt im Live-Modus eine GPS-Vorbelegung mit
+„Tap-to-Adjust"-Korrektur auf einer Karte (siehe `fahrplan.md` §M5a,
+Akzeptanzkriterium „GPS-Korrektur per Karten-Tap funktioniert"). Die
+vollständige Kartenansicht (Marker-Liste, Clustering, Filter, URL-State,
+Popup-Navigation) ist als eigener Meilenstein **M6** definiert. Ohne
+Vorentscheidung würde M5a entweder das M6-Akzeptanzkriterium reißen oder
+M5a und M6 müssten zu einem schwer abgrenzbaren Block verschmelzen.
+
+**Entscheidungen:**
+
+1. **Scope-Schnitt M5a ↔ M6 (Option A):** M5a liefert eine eigenständige,
+   minimale Komponente `LocationPickerMap`: ein einzelner verschiebbarer
+   Marker auf einer MapLibre-Karte, kein Clustering, kein Filter, kein
+   URL-Sync, kein Popup. Tap setzt `lat`/`lon` im Form-State. M6 baut
+   später die vollständige `MapView` (Marker-Liste, Clustering, Filter,
+   URL-State, Popup-Navigation) als eigene Komponente — `LocationPickerMap`
+   wird in M6 entweder als Basis ausgebaut oder bleibt eigenständig
+   bestehen, je nach Refactor-Aufwand. Verworfen wurden Option B
+   (M6 vorziehen / mit M5a verschmelzen — macht M5a unabnehmbar) und
+   Option C (Karten-Tap streichen, nur Lat/Lon-Felder + Plus Code —
+   verletzt Akzeptanzkriterium und ADR-011-UX).
+
+2. **Tile-Proxy in M5a (Option A-Folge):** Da `LocationPickerMap`
+   MapLibre-Tiles braucht, wird der in `architecture.md` §API
+   skizzierte Tile-Proxy `GET /api/tiles/{z}/{x}/{y}` aus dem M6-Scope
+   nach M5a vorgezogen. MapTiler-API-Key bleibt serverseitig in
+   `MAPTILER_API_KEY`-ENV. Implementierung: dünner FastAPI-Router
+   `app/routes/tiles.py`, der die Tile-URL bei MapTiler abruft und den
+   Body mit `Cache-Control: public, max-age=86400` durchreicht; bei
+   Upstream-Fehler 502 ohne Detail-Leak. Auth: eingeloggt erforderlich
+   (Session-Cookie); RLS-Setup nicht nötig, weil Tiles
+   nutzer-unabhängig sind.
+
+3. **MapLibre-Setup im Frontend:** `react-map-gl` + `maplibre-gl`
+   werden als Runtime-Dependencies aufgenommen (beide MIT, lizenz-
+   konform). `LocationPickerMap` lädt Tiles über
+   `process.env.NEXT_PUBLIC_TILE_URL` mit Default
+   `'/api/tiles/{z}/{x}/{y}'` (Same-Origin, Cookies werden mitgesendet).
+   Map-Style: das in MapTiler kostenlos verfügbare „basic-v2" oder
+   Vergleichbares; finale Style-Wahl erfolgt während der Implementierung,
+   ohne ADR.
+
+4. **Geocoding bewusst nicht in M5a:** MapTiler-Geocoding-Proxy
+   (`GET /api/geocode?q=...`) bleibt im M6-Scope. Im Live-Modus reicht
+   GPS + manueller Tap; Adress-Suche ist sekundär.
+
+5. **M6-Restscope:** M6 deckt weiterhin Marker-Liste aller sichtbaren
+   Events, Clustering, Zeitraum- und Personen-Filter, URL-State des
+   Viewports, Popup mit Detail-Link sowie den Geocoding-Proxy ab. Die
+   Tile-Auslieferung ist mit M5a bereits erledigt.
+
+**Konsequenzen:**
+
+- M5a wird um `LocationPickerMap` (Frontend) und Tile-Proxy (Backend)
+  erweitert. Aufwand überschaubar (~1 Komponente + 1 Route +
+  Tile-Caching).
+- M6 wird kleiner, weil Tile-Auslieferung schon vorhanden ist. M6
+  konzentriert sich auf Listen-/Filter-/Popup-UX.
+- Frontend bekommt zwei neue Runtime-Dependencies (`react-map-gl`,
+  `maplibre-gl`). Beide sind in `project-context.md` §3 als „empfohlen"
+  geführt — keine Freigabe nötig.
+- Backend bekommt eine neue ENV-Variable `MAPTILER_API_KEY`.
+  `.env.example` und README werden in M5a entsprechend ergänzt.
+- Falls M6 später entscheidet, `LocationPickerMap` zur Basis der
+  `MapView` umzubauen, ist das ein Refactor innerhalb des
+  Frontend-Map-Moduls und freigabefrei.
+
+**Verworfene Alternativen:**
+
+- B (M6 vorziehen / verschmelzen): macht M5a unabnehmbar groß, schwer
+  testbar, schwerer Review.
+- C (kein Karten-Tap, nur Lat/Lon-Felder): verletzt M5a-Akzeptanz-
+  kriterium und ADR-11-UX (Live-Modus muss in <30s vom Tap zur ersten
+  gespeicherten Application kommen — manuelle Lat/Lon-Eingabe ist auf
+  Mobile zu langsam).
+
+---
+
+## ADR-023 — App-PIN-Hashing clientseitig via PBKDF2 (Web Crypto API)
+
+**Status:** Akzeptiert (2026-04-26)
+
+**Kontext:** ADR-015 verlangt eine clientseitige App-PIN-Sperre als
+Schutz gegen Schulterblick und kurze fremde Geräteübernahme. PIN ist
+4–6 Ziffern, wird gehasht in IndexedDB abgelegt, Inaktivitäts-Sperre
+nach 60 s, Zwangs-Logout nach 5 Fehlversuchen.
+`project-context.md` §6 lässt „PBKDF2 oder Argon2-WASM" zu. Eine
+Festlegung war offen.
+
+**Schutzziel** laut `architecture.md` §App-PIN-Sperre: UI-Sperre gegen
+Schulterblick und kurze fremde Übernahme eines **entsperrten** Geräts.
+**Nicht** im Schutzziel: forensischer Zugriff auf das entsperrte Gerät
+oder die IndexedDB. Letzteres ist Job von Geräte-Sperre und Auth-System
+(Cookie wird beim Zwangs-Logout invalidiert).
+
+**Entscheidungen:**
+
+1. **Algorithmus:** PBKDF2-SHA-256 via Web Crypto API
+   (`crypto.subtle.deriveBits`). Browser-nativ, keine externe
+   Dependency, kein WASM-Bundle.
+
+2. **Parameter:**
+   - **Iterationen:** 600.000 (OWASP-Empfehlung 2024 für PBKDF2-SHA-256).
+   - **Salt:** 16 Byte zufällig per `crypto.getRandomValues`, einmalig
+     pro User beim Setzen der PIN, in IndexedDB neben dem Hash gespeichert.
+   - **Output-Länge:** 32 Byte (256 Bit).
+   - **Encoding:** Base64 für Storage.
+
+3. **Storage-Layout in IndexedDB** (`hcmap-pin`-Object-Store, Key
+   `pin_v1`):
+   ```json
+   {
+     "version": 1,
+     "algorithm": "PBKDF2-SHA256",
+     "iterations": 600000,
+     "salt_b64": "...",
+     "hash_b64": "...",
+     "fail_count": 0,
+     "set_at": "ISO-8601"
+   }
+   ```
+   `version` und `algorithm` sind explizit, damit ein späterer Wechsel
+   auf Argon2id ohne Datenverlust möglich ist (alter Hash bleibt
+   verifizierbar, neuer wird beim nächsten erfolgreichen Entsperren mit
+   neuer Algorithmus-Variante geschrieben).
+
+4. **Vergleich:** Konstantzeit-Vergleich der Base64-Strings, um
+   Timing-Side-Channels zu vermeiden — auch wenn das Risiko in einer
+   reinen Browser-Umgebung niedrig ist.
+
+5. **Fehlversuch-Zähler:** `fail_count` wird **vor** dem Hash-Vergleich
+   inkrementiert und persistiert; bei Erfolg auf 0 zurückgesetzt. Bei
+   `fail_count >= 5` wird die App den Server-Logout-Endpoint
+   (`POST /api/auth/logout`) aufrufen und IndexedDB
+   (Pin-Store + RxDB-Daten in M5b) leeren.
+
+6. **Inaktivitäts-Timer:** Default 60 s, aus User-Profil konfigurierbar
+   (in M5a-Profil-UI). Timer-Reset bei `pointerdown`, `keydown`,
+   `visibilitychange`. Bei Timer-Ablauf wird ein Vollbild-Overlay
+   angezeigt; Navigation und Mutations werden blockiert. Implementierung
+   in einer eigenen Component `LockOverlay` plus Hook `usePinLock`.
+
+7. **Web-Worker nicht erforderlich:** PBKDF2 mit 600.000 Iterationen
+   dauert auf modernem Mobile ~300–500 ms. Das Vollbild-Overlay zeigt
+   während dieser Zeit einen Spinner. Ein Web-Worker wäre nur sinnvoll,
+   wenn die Hauptseite während des Hashings interaktiv bleiben müsste —
+   sie ist es per Design nicht.
+
+8. **Späterer Algorithmus-Wechsel:** Falls das Schutzziel später um
+   „verlorenes Gerät" erweitert wird, kann ein Folge-ADR Argon2id-WASM
+   einführen. Das `version`/`algorithm`-Feld erlaubt sanfte Migration
+   ohne erzwungenes PIN-Zurücksetzen.
+
+**Konsequenzen:**
+
+- Keine neuen externen Abhängigkeiten — `crypto.subtle` ist im
+  Browser-Standard. Kein Bundle-Overhead.
+- Konsistenz Backend/Frontend ist **algorithmisch unterschiedlich**
+  (Backend nutzt Argon2id für Login-Passwörter via pwdlib, ADR-019).
+  Das ist akzeptiert: unterschiedliche Schutzziele, unterschiedliche
+  Anforderungen. Login-Passwörter sind im worst case auch offline
+  angreifbar (Datenbank-Dump), eine PIN nicht (Server-Logout nach 5
+  Versuchen).
+- Brute-Force-Resistenz für eine 4-stellige PIN bei Datenbank-Dump-
+  Szenario ist gering (10⁴ Versuche × 300 ms = ~50 min auf einer GPU
+  noch deutlich kürzer). Das ist explizit kein Schutzziel und durch
+  den Server-Logout-Mechanismus für Online-Brute-Force gedeckt.
+- IndexedDB-Schema bekommt einen neuen Object-Store `hcmap-pin`. Wird
+  beim ersten PIN-Setzen erstellt. Migration in M5b nicht nötig
+  (RxDB-Object-Stores sind unabhängig).
+
+**Verworfene Alternativen:**
+
+- **Argon2id-WASM** (`hash-wasm` oder `argon2-browser`): überdimensioniert
+  für das dokumentierte Schutzziel; 50–200 KB WASM-Bundle, neue
+  Abhängigkeit (freigabepflichtig nach CLAUDE.md §4). Sinnvoll, wenn
+  Schutzziel um „verlorenes Gerät, IndexedDB lesbar" erweitert wird —
+  dann separater ADR.
+- **Bcrypt-JS:** weder speicherhart noch durch Web-Crypto unterstützt;
+  zusätzliche JS-Dependency ohne Vorteil.
+- **Klartext-PIN in IndexedDB:** trivial, aber bricht das minimale
+  Sicherheitsversprechen einer PIN-Sperre vollständig.
+- **PIN-Verifikation auf Server:** würde funktionieren, aber bricht
+  die Offline-Tauglichkeit (RxDB im Funkloch, ADR-017) und macht aus
+  der UI-Sperre einen vollwertigen zweiten Auth-Faktor — größere
+  Architekturwirkung als gewünscht.
 
 ---
 

--- a/docs/fahrplan.md
+++ b/docs/fahrplan.md
@@ -27,9 +27,10 @@ Status-Marker (gemäß CLAUDE.md Abschnitt 7):
 
 - **Stand vom:** 2026-04-26
 - **Laufende Phase:** Phase 1 (MVP) — gestartet
-- **Aktiver Schritt:** keiner (M4 abgeschlossen)
-- **Nächster Schritt:** M5a — Event-Erfassung Live-Modus (Scope erweitert per ADR-022/-023)
+- **Aktiver Schritt:** M5a (Live-Modus) — Sub-Schritt **M5a.1 [ERLEDIGT] 2026-04-26**
+- **Nächster Schritt:** M5a.2 — Frontend Startseite, Suche, Export-UI
 - **Offene STOPP-Situationen:** keine
+- **Offene Beobachtungen:** mypy `app/auth/routes.py:20` meldet einen vorbestehenden Fehler (Value of type variable "models.UP" of "FastAPIUsers" cannot be "User"). Der Fehler liegt im M2-Modul, ist nicht durch M5a.1 verursacht und wird separat aufgelöst, sobald jemand am Auth-Modul arbeitet (siehe ADR-024 §Konsequenzen).
 
 ## Überblick
 
@@ -50,7 +51,11 @@ Jede Phase besteht aus nummerierten Meilensteinen (M0, M1, …). Innerhalb einer
 | 1 MVP   | M2          | Auth & User-Management (Backend)                 | [ERLEDIGT] 2026-04-25 |
 | 1 MVP   | M3          | Event- und Application-API (Backend)             | [ERLEDIGT] 2026-04-25 |
 | 1 MVP   | M4          | Frontend-Grundgerüst & Auth-Flow                 | [ERLEDIGT] 2026-04-25 |
-| 1 MVP   | M5a         | Event-Erfassung Live-Modus (mobile, GPS, Timer)  | [OFFEN]     |
+| 1 MVP   | M5a         | Event-Erfassung Live-Modus (mobile, GPS, Timer)  | [IN ARBEIT] |
+| 1 MVP   | M5a.1       | └─ Backend-Live-Endpoints + Tile-Proxy           | [ERLEDIGT] 2026-04-26 |
+| 1 MVP   | M5a.2       | └─ Frontend Startseite, Suche, Export            | [OFFEN]     |
+| 1 MVP   | M5a.3       | └─ Frontend Live-Modus + LocationPickerMap      | [OFFEN]     |
+| 1 MVP   | M5a.4       | └─ App-PIN-Sperre (PBKDF2 / Web Crypto API)     | [OFFEN]     |
 | 1 MVP   | M5b         | Offline-Resilienz (RxDB-Sync)                    | [OFFEN]     |
 | 1 MVP   | M5c         | Nachträgliche Erfassung & Bearbeitung            | [OFFEN]     |
 | 1 MVP   | M6          | Kartenansicht                                    | [OFFEN]     |
@@ -377,6 +382,34 @@ Jede Phase besteht aus nummerierten Meilensteinen (M0, M1, …). Innerhalb einer
 - Lückenberechnung: zwischen Application[i].ended_at und Application[i+1].started_at sichtbar in der Detailansicht.
 
 **Abhängigkeiten:** M3, M4.
+
+**Status `[ERLEDIGT]` 2026-04-26 (M5a.1, Backend-Anteil):**
+- Sechs neue Backend-Routen produktiv (`app/routes/events.py:start/end`,
+  `app/routes/applications.py:end`, geschachteltes `applications/start`
+  in `events.py`, `app/routes/persons.py:quick`, neuer
+  `app/routes/tiles.py`). Insgesamt jetzt 50 Routen unter `/api/`.
+- Service-Layer-Erweiterungen: `events.start_event/end_event`,
+  `applications.start_application/end_application`,
+  `persons.quick_create_person`. End-Funktionen sind idempotent.
+- Default-Performer/Recipient-Logik im Live-Pfad (Regel-002 +
+  Self-Bondage-Default), Auto-Participant-Reuse aus M3, Catalog-
+  Approval-Check unverändert.
+- MapTiler-Tile-Proxy mit serverseitigem API-Key,
+  `Cache-Control: public, max-age=86400`, Auth-Pflicht, Pfad-Param-
+  Validierung (`z` 0–22). Empty-Key → 503, Upstream-Fehler → 502.
+- 21 neue HTTP-Tests (test_events_live_api: 5, test_applications_live_api:
+  6, test_persons_quick_api: 4, test_tiles_proxy: 6). Backend-Suite
+  74/74 grün gegen Postgres 16 + PostGIS 3.4. ruff check + ruff
+  format --check clean. mypy meldet einen vorbestehenden M2-Fehler in
+  `app/auth/routes.py:20` (außerhalb M5a.1-Scope).
+- Neue ENV-Variablen: `HCMAP_MAPTILER_API_KEY` (leer = Proxy
+  deaktiviert) und `HCMAP_MAPTILER_STYLE` (Default `basic-v2`).
+  `.env.example` aktualisiert.
+- `httpx` aus Dev-Group in Runtime-Dependencies verschoben (Tile-Proxy
+  zur Laufzeit). `uv.lock` aktualisiert.
+- ADR-024 dokumentiert die zehn Detail-Entscheidungen.
+- README-Phase-Badge auf `M5a.1-erledigt`, CHANGELOG-Eintrag,
+  Projektstatus-Tabelle aktualisiert.
 
 ---
 

--- a/docs/fahrplan.md
+++ b/docs/fahrplan.md
@@ -25,10 +25,10 @@ Status-Marker (gemäß CLAUDE.md Abschnitt 7):
 
 ## Aktueller Stand
 
-- **Stand vom:** 2026-04-25
+- **Stand vom:** 2026-04-26
 - **Laufende Phase:** Phase 1 (MVP) — gestartet
 - **Aktiver Schritt:** keiner (M4 abgeschlossen)
-- **Nächster Schritt:** M5a — Event-Erfassung Live-Modus
+- **Nächster Schritt:** M5a — Event-Erfassung Live-Modus (Scope erweitert per ADR-022/-023)
 - **Offene STOPP-Situationen:** keine
 
 ## Überblick
@@ -332,14 +332,25 @@ Jede Phase besteht aus nummerierten Meilensteinen (M0, M1, …). Innerhalb einer
 
 **Ziel:** Performer kann ein Event in der Situation starten, Applications live erfassen und das Event abschließen — alles vom Mobilgerät aus, mit minimaler Bedienzeit. Live-Modus ist die Hauptansicht der App (siehe ADR-011).
 
-**Deliverables:**
+**Scope-Erweiterungen (2026-04-26):** Tile-Proxy und minimale `LocationPickerMap` sind aus M6 nach M5a vorgezogen (siehe ADR-022). PIN-Hashing-Algorithmus festgelegt auf PBKDF2 via Web Crypto API (siehe ADR-023).
+
+**Backend-Anteil (fünf Live-Endpoints + Tile-Proxy):**
+- `POST /api/events/start` setzt `started_at = now()`, legt Event mit Default-Reveal-Flag an, verknüpft den Creator implizit als Participant (analog `POST /api/events`).
+- `POST /api/events/{id}/end` setzt `ended_at = now()`, mit Idempotenz-Check (zweiter Aufruf ist No-Op).
+- `POST /api/events/{event_id}/applications/start` legt eine Application mit `started_at = now()`, `sequence_no` automatisch hochgezählt; Performer-Default = `current_user.person_id`, Recipient aus Payload (oder Self-Bondage falls leer).
+- `POST /api/applications/{id}/end` setzt `ended_at = now()`, idempotent.
+- `POST /api/persons/quick` (admin + editor): legt Person mit `origin = 'on_the_fly'`, `linkable = false` an. Pflichtfeld `name`, optional `alias`. Siehe ADR-014, Regel-004.
+- **Tile-Proxy** `GET /api/tiles/{z}/{x}/{y}` (siehe ADR-022): MapTiler-Tiles über Backend mit `Cache-Control: public, max-age=86400`, Auth via Session-Cookie, MAPTILER_API_KEY serverseitig.
+
+**Frontend-Deliverables:**
 - Startseite mit großem „Neues Event starten"-Knopf, Liste der letzten Events und **„On this day"-Sektion** (siehe ADR-015), wenn Treffer vorhanden.
 - **Volltext-Suchleiste** in der Hauptnavigation, Ergebnisliste mit RLS-konformen Treffern aus Events und Applications.
-- **App-PIN-Sperre** (siehe ADR-015): User kann im Profil eine 4–6-stellige PIN setzen; UI sperrt sich nach Inaktivität (Default 60s) oder per Knopf; PIN-Eingabe entsperrt nur die UI, Server-Session bleibt; nach 5 Fehlversuchen Zwangs-Logout. Hashing clientseitig via Web Crypto API, Storage in IndexedDB.
+- **App-PIN-Sperre** (siehe ADR-015 + ADR-023): User kann im Profil eine 4–6-stellige PIN setzen; UI sperrt sich nach Inaktivität (Default 60s) oder per Knopf; PIN-Eingabe entsperrt nur die UI, Server-Session bleibt; nach 5 Fehlversuchen Zwangs-Logout. Hashing clientseitig via PBKDF2-SHA-256 (Web Crypto API, 600.000 Iterationen, 16-Byte-Salt), Storage in IndexedDB-Object-Store `hcmap-pin`.
 - **Export-UI** im Profil: „Meine Daten exportieren" (JSON/CSV).
+- **`LocationPickerMap`-Komponente** (siehe ADR-022): minimaler MapLibre-basierter Karten-Picker, ein verschiebbarer Marker, kein Clustering/Filter/URL-Sync. Tile-URL aus `NEXT_PUBLIC_TILE_URL` (Default `/api/tiles/{z}/{x}/{y}`). Wird in M6 zur vollwertigen `MapView` ausgebaut.
 - Live-Event-Anlegen-Flow:
   - GPS via Browser-Geolocation-API anfordern, Lat/Lon vorbelegen.
-  - Karte mit aktueller Position, Tap-to-Adjust für manuelle Korrektur.
+  - `LocationPickerMap` mit aktueller Position, Tap-to-Adjust für manuelle Korrektur.
   - Recipient-Auswahl aus Personen-Liste.
   - Performer = eingeloggter User per Default (siehe ADR-010).
   - `POST /api/events/start` setzt `started_at = now()`.
@@ -416,15 +427,19 @@ Jede Phase besteht aus nummerierten Meilensteinen (M0, M1, …). Innerhalb einer
 
 **Ziel:** Events werden auf einer Karte visualisiert.
 
+**Scope-Anpassung (2026-04-26):** MapLibre/`react-map-gl`-Integration, Tile-Proxy und Karten-Klick→Lat/Lon-Picker sind mit M5a vorgezogen (siehe ADR-022). M6 baut darauf auf und liefert die volle Listen-/Filter-/Popup-UX.
+
 **Deliverables:**
-- MapLibre GL JS via `react-map-gl` integriert.
-- MapTiler-API-Key serverseitig verwaltet, ggf. über Backend-Proxy ausgeliefert.
+- ~~MapLibre GL JS via `react-map-gl` integriert.~~ (in M5a erledigt)
+- ~~MapTiler-API-Key serverseitig verwaltet, ggf. über Backend-Proxy ausgeliefert.~~ (in M5a erledigt)
 - Marker-Darstellung aller für den Nutzer sichtbaren Events.
 - Popup mit Kurzinfo + Link zur Event-Detailseite.
-- Clustering bei hoher Dichte.
+- Clustering bei hoher Dichte (z. B. via `supercluster`).
 - Filter: Zeitraum, Beteiligte (gemäß RLS).
 - Kartenzustand (Viewport) URL-persistiert.
-- Grundlage für Eingabe-Use-Case aus M5: Karten-Klick liefert Lat/Lon zurück.
+- **Geocoding-Proxy** `GET /api/geocode?q=...` als MapTiler-Wrapper, eingeloggt erforderlich.
+- ~~Grundlage für Eingabe-Use-Case aus M5: Karten-Klick liefert Lat/Lon zurück.~~ (in M5a als `LocationPickerMap` erledigt)
+- Optional: Refactor von `LocationPickerMap` zur Basis der `MapView` oder beide eigenständig — Entscheidung in M6, freigabefrei.
 
 **Akzeptanzkriterien:**
 - Events erscheinen als Marker.


### PR DESCRIPTION
## Summary

Setzt **M5a.1** aus dem Fahrplan um — den Backend-Anteil des Live-Modus. Sechs neue Routen plus Tile-Proxy. Frontend-Anteil folgt mit M5a.2/.3/.4 in eigenen PRs.

- Sechs neue Backend-Endpunkte für die Live-Erfassung (events/start, events/{id}/end, applications/start, applications/{id}/end, persons/quick) und ein MapTiler-Tile-Proxy mit serverseitigem API-Key.
- 21 neue HTTP-Tests gegen Postgres 16 + PostGIS 3.4, Backend-Suite jetzt 74/74 grün.
- ADR-022 und ADR-023 ziehen den minimalen LocationPicker bzw. legen das App-PIN-Hashing (PBKDF2) fest; ADR-024 dokumentiert die zehn Detail-Entscheidungen für M5a.1.

## Was sich ändert

### Backend

- **Live-Endpunkte:** \`POST /api/events/start\`, \`POST /api/events/{id}/end\` und ihre Pendants für Applications. Beide End-Routen sind **idempotent** (zweiter Aufruf ändert \`ended_at\` nicht).
- **\`POST /api/persons/quick\`** (admin + editor): On-the-fly-Personenanlage mit \`origin = on_the_fly\` und \`linkable = false\` (Regel-004, ADR-014).
- **\`GET /api/tiles/{z}/{x}/{y}\`**: Auth-Pflicht, \`Cache-Control: public, max-age=86400\`, Pfad-Param-Validierung (z 0–22, x/y ≥ 0). Empty-Key → 503, Netzwerk-/Upstream-Fehler → 502.
- Service-Layer-Erweiterungen wiederverwenden die M3-Auto-Participant-Logik — kein DB-Trigger.

### Konfiguration

- Neue ENV-Variablen \`HCMAP_MAPTILER_API_KEY\` und \`HCMAP_MAPTILER_STYLE\` (Default \`basic-v2\`).
- \`httpx\` aus den Dev- in die Runtime-Dependencies verschoben (Tile-Proxy zur Laufzeit).
- \`uv.lock\` aktualisiert.

### Doku

- **ADR-022** (LocationPicker + Tile-Proxy aus M6 nach M5a vorgezogen)
- **ADR-023** (App-PIN-Hashing via PBKDF2-SHA-256, Web Crypto API)
- **ADR-024** (Implementierungsstrategie M5a.1 — zehn Detail-Entscheidungen)
- Fahrplan: M5a auf \`[IN ARBEIT]\`, M5a.1 \`[ERLEDIGT] 2026-04-26\`, neue Sub-Schritte M5a.2/.3/.4 als \`[OFFEN]\`. M6-Scope reduziert (Tile-Proxy in M5a.1 erledigt).
- README-Phase-Badge auf \`M5a.1-erledigt\`, CHANGELOG-Eintrag, Routen-Zähler 44 → 50.

## Warum

Live-Modus-Endpunkte wurden in ADR-020 §A1 bewusst aus M3 herausgehalten, weil sie an die UI-Mechanik koppeln. Mit M5a.1 wird das Backend-Fundament gelegt, sodass die folgenden Frontend-Sub-Schritte (M5a.2/.3/.4) ohne weitere Backend-Änderungen anbinden können. Der Tile-Proxy wird per ADR-022 aus M6 vorgezogen, weil M5a.3 bereits eine Karte braucht.

## Hinweise für den Review

- **Pre-existing mypy-Befund:** \`backend/app/auth/routes.py:20\` meldet \`Value of type variable "models.UP" of "FastAPIUsers" cannot be "User"\`. Dieser Fehler existiert bereits auf \`main\` (verifiziert per \`git stash\`) und liegt im M2-Modul. Eine Korrektur ist Scope-Erweiterung in fremde Modulgrenze (CLAUDE.md §6 + §8) — wird separat gefixt. Dokumentiert in [docs/decisions.md](docs/decisions.md) ADR-024 §Konsequenzen und [docs/fahrplan.md](docs/fahrplan.md) §Aktueller Stand.
- **Idempotenz** der End-Routen ist bewusst gewählt (kein 409 Conflict) — überlebt doppelte Klicks, Reconnect-Retries und RxDB-Replay (ab M5b) ohne Sonderbehandlung.
- **Recipient als Participant statt Schema-Spalte:** Das Event-Schema bleibt unverändert; die UI hält den ausgewählten Recipient im Client-State. Begründung in ADR-024 §E.
- **Tile-Proxy ohne Key liefert 503** (gewollt). Vor M11 muss der Key im Deployment gesetzt werden.

## Test plan

- [x] \`uv run ruff check app tests\` — clean
- [x] \`uv run ruff format --check app tests\` — clean
- [x] \`uv run pytest -q\` — 74/74 passed
- [x] mypy: meine Änderungen sind clean; pre-existing M2-Befund unverändert (siehe Hinweise oben)
- [ ] Manueller Smoke-Test gegen lokales Postgres+PostGIS: \`/api/events/start\` → \`/api/events/{id}/applications/start\` → \`/api/applications/{id}/end\` → \`/api/events/{id}/end\` (im Reviewer-Setup nachstellbar)
- [ ] Tile-Proxy mit echtem MapTiler-Key gegen \`/api/tiles/3/4/5\` (im Reviewer-Setup nachstellbar)

## Fahrplan / ADR

- Fahrplan: M5a.1 (Phase 1, MVP)
- Neue ADRs: ADR-022, ADR-023, ADR-024

🤖 Generated with [Claude Code](https://claude.com/claude-code)