### PR TITLE
fix(auth): User erbt von SQLAlchemyBaseUserTableUUID — mypy --strict clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Bis zum ersten Go-Live (M11) bleibt das Projekt auf `0.0.0`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **M2 — fastapi-users-Typing:** `app/auth/routes.py:20` warf seit M2
+  `Value of type variable "models.UP" of "FastAPIUsers" cannot be "User"`
+  unter `mypy --strict`. Behoben durch Vererbung von
+  `SQLAlchemyBaseUserTableUUID` (ADR-025); Spalten-Overrides in einem
+  `if not TYPE_CHECKING`-Block halten Schema und Verhalten identisch
+  (UUIDv7-Default per ADR-018, server_default auf den Boolean-Flags,
+  benannter UniqueConstraint statt inline `unique=True/index=True`).
+  Fünf bisherige `# type: ignore[type-var]`-Workarounds in
+  `app/auth/manager.py` sind entfernt. `mypy --strict` clean
+  (50 Source-Files, 0 Errors). Schema-Drift verifiziert: keine
+  Migration nötig. Backend-Suite 74/74 grün.
+
 ### Added
 
 - **M5a.1 — Backend-Live-Endpoints + Tile-Proxy:** Sechs neue Backend-

--- a/backend/app/auth/manager.py
+++ b/backend/app/auth/manager.py
@@ -41,7 +41,7 @@ def _password_helper() -> PasswordHelper:
     return PasswordHelper(hasher)
 
 
-class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):  # type: ignore[type-var]
+class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     """Application UserManager.
 
     ``reset_password_token_secret`` and ``verification_token_secret`` are
@@ -51,7 +51,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):  # type: ignor
 
     def __init__(
         self,
-        user_db: SQLAlchemyUserDatabase[User, uuid.UUID],  # type: ignore[type-var]
+        user_db: SQLAlchemyUserDatabase[User, uuid.UUID],
         email_backend: EmailBackend,
     ) -> None:
         password_helper = _password_helper()
@@ -80,12 +80,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):  # type: ignor
 
 async def get_user_db(
     session: AsyncSession = Depends(get_session),
-) -> AsyncIterator[SQLAlchemyUserDatabase[User, uuid.UUID]]:  # type: ignore[type-var]
-    yield SQLAlchemyUserDatabase(session, User)  # type: ignore[type-var]
+) -> AsyncIterator[SQLAlchemyUserDatabase[User, uuid.UUID]]:
+    yield SQLAlchemyUserDatabase(session, User)
 
 
 async def get_user_manager(
-    user_db: SQLAlchemyUserDatabase[User, uuid.UUID] = Depends(get_user_db),  # type: ignore[type-var]
+    user_db: SQLAlchemyUserDatabase[User, uuid.UUID] = Depends(get_user_db),
     email_backend: EmailBackend = Depends(get_email_backend),
 ) -> AsyncIterator[UserManager]:
     yield UserManager(user_db, email_backend)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,15 +1,20 @@
 """User model.
 
-Layout follows the fastapi-users SQLAlchemy adapter so M2 can plug it in
-without schema changes. The mandatory 1:1 link to Person is enforced at
-the database level (NOT NULL UNIQUE) per ADR-010.
+Inherits from ``SQLAlchemyBaseUserTableUUID`` so ``FastAPIUsers[User, …]``
+type-checks correctly (ADR-025). All concrete columns are still declared
+locally so the database schema stays unchanged: UUIDv7 default (ADR-018),
+unique constraint via ``__table_args__`` (not via inline ``unique=True``),
+and ``server_default`` on the boolean flags. The mandatory 1:1 link to
+Person is enforced at the database level (NOT NULL UNIQUE) per ADR-010.
 """
 
 from __future__ import annotations
 
 import enum
 import uuid
+from typing import TYPE_CHECKING
 
+from fastapi_users_db_sqlalchemy import SQLAlchemyBaseUserTableUUID
 from sqlalchemy import Enum, ForeignKey, Index, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
@@ -25,7 +30,7 @@ class UserRole(str, enum.Enum):
     VIEWER = "viewer"
 
 
-class User(Base, TimestampMixin, SoftDeleteMixin):
+class User(SQLAlchemyBaseUserTableUUID, Base, TimestampMixin, SoftDeleteMixin):
     __tablename__ = "user"
     __table_args__ = (
         UniqueConstraint("email", name="uq_user_email"),
@@ -33,14 +38,26 @@ class User(Base, TimestampMixin, SoftDeleteMixin):
         Index("ix_user_role", "role"),
     )
 
-    id: Mapped[uuid.UUID] = pk_column()
-    email: Mapped[str] = mapped_column(String(320), nullable=False)
-    hashed_password: Mapped[str] = mapped_column(String(1024), nullable=False)
-    is_active: Mapped[bool] = mapped_column(nullable=False, default=True, server_default="true")
-    is_verified: Mapped[bool] = mapped_column(nullable=False, default=False, server_default="false")
-    is_superuser: Mapped[bool] = mapped_column(
-        nullable=False, default=False, server_default="false"
-    )
+    # The fastapi-users base class declares id/email/hashed_password/is_active/
+    # is_superuser/is_verified as Mapped[...] columns at runtime *and* as
+    # plain types under TYPE_CHECKING. To preserve the protocol-friendly
+    # type view while overriding the runtime column properties (UUIDv7
+    # default per ADR-018, unique-via-__table_args__, server_default on
+    # the booleans), we mirror that pattern here: at type-check time only
+    # the parent's plain-type declarations are visible; at runtime our
+    # mapped_column() overrides win.
+    if not TYPE_CHECKING:
+        id: Mapped[uuid.UUID] = pk_column()
+        email: Mapped[str] = mapped_column(String(320), nullable=False)
+        hashed_password: Mapped[str] = mapped_column(String(1024), nullable=False)
+        is_active: Mapped[bool] = mapped_column(nullable=False, default=True, server_default="true")
+        is_verified: Mapped[bool] = mapped_column(
+            nullable=False, default=False, server_default="false"
+        )
+        is_superuser: Mapped[bool] = mapped_column(
+            nullable=False, default=False, server_default="false"
+        )
+
     role: Mapped[UserRole] = mapped_column(
         Enum(UserRole, name="user_role", values_callable=lambda e: [m.value for m in e]),
         nullable=False,

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -50,6 +50,7 @@ Status-Legende:
 | ADR-022 | LocationPicker und Tile-Proxy in M5a vorgezogen                 | Accepted | 2026-04-26  |
 | ADR-023 | App-PIN-Hashing clientseitig via PBKDF2 (Web Crypto API)        | Accepted | 2026-04-26  |
 | ADR-024 | Implementierungsstrategie M5a.1 (Live-Endpoints + Tile-Proxy)   | Accepted | 2026-04-26  |
+| ADR-025 | User-Modell erbt von SQLAlchemyBaseUserTableUUID (typing-fix)   | Accepted | 2026-04-26  |
 
 ---
 
@@ -1700,6 +1701,96 @@ dieses Backend-Paket um.
   `httpx.AsyncClient`-Instance — Verbindungs-Pool-Verlust.
 - G2 (httpx in dev-Group lassen + Production-Imports): bricht Runtime
   in der Produktion.
+
+---
+
+## ADR-025 — User-Modell erbt von SQLAlchemyBaseUserTableUUID (typing-fix)
+
+**Status:** Akzeptiert (2026-04-26)
+
+**Kontext:** `app/auth/routes.py:20` deklariert
+`fastapi_users = FastAPIUsers[User, uuid.UUID](...)`. Der TypeVar `UP`
+in `FastAPIUsers[UP, ID]` ist an einen Protokoll-Vertrag gebunden, den
+unser User-Modell aus M2 nicht statisch erfüllt — User erbte direkt von
+`Base, TimestampMixin, SoftDeleteMixin` und deklarierte alle benötigten
+Spalten (`id`, `email`, `hashed_password`, `is_active`, `is_superuser`,
+`is_verified`) als `Mapped[...]`. Zur Laufzeit funktioniert das via
+Duck-Typing; mypy aber sieht nur die `Mapped[...]`-Descriptor-Typen, nicht
+die Plain-Types, die das Protokoll erwartet. Resultat: persistenter
+mypy-Fehler `Value of type variable "models.UP" of "FastAPIUsers" cannot
+be "User"` plus fünf `# type: ignore[type-var]`-Workarounds in
+`app/auth/manager.py`. Die DoD aus `project-context.md` §7 verlangt
+`mypy --strict` clean — dieser Befund war die einzige Abweichung.
+
+**Entscheidungen:**
+
+1. **Vererbung erweitern (A):** `User` erbt jetzt von
+   `SQLAlchemyBaseUserTableUUID, Base, TimestampMixin, SoftDeleteMixin`.
+   `SQLAlchemyBaseUserTableUUID` deklariert die fastapi-users-Pflicht-
+   Spalten unter `if TYPE_CHECKING` als Plain-Types (`id: UUID_ID`,
+   `email: str`, `hashed_password: str`, `is_active: bool`,
+   `is_superuser: bool`, `is_verified: bool`) und unter `else` als
+   `Mapped[...]`-Spalten — genau das Muster, das mypy als Protokoll-
+   Erfüllung sieht.
+
+2. **Spalten-Overrides per `if not TYPE_CHECKING` (B):** Die geerbten
+   Spaltendefinitionen passen nicht 1:1 zu unserem Schema:
+   - Parent setzt `id` mit `default=uuid.uuid4`. Wir brauchen UUIDv7
+     (ADR-018) → `id: Mapped[uuid.UUID] = pk_column()`.
+   - Parent setzt `email` mit `unique=True, index=True` direkt am
+     Column. Wir haben einen benannten `UniqueConstraint` in
+     `__table_args__` → ohne Override gäbe es einen zusätzlichen
+     impliziten Index plus einen anonymen Unique-Constraint.
+   - Parent setzt `is_active`/`is_superuser`/`is_verified` ohne
+     `server_default`. Unser Schema nutzt `server_default="true"`
+     bzw. `"false"` → ohne Override würde der Server-Default
+     verschwinden.
+   Die Overrides werden in einem `if not TYPE_CHECKING:`-Block
+   deklariert. Damit sind sie zur Laufzeit für SQLAlchemy aktiv, aber
+   für mypy unsichtbar — die Plain-Type-Sicht der Eltern bleibt
+   erhalten und das Protokoll wird erfüllt.
+
+3. **type-ignore-Cleanup (C):** Die fünf `# type: ignore[type-var]`-
+   Kommentare in `app/auth/manager.py` (UserManager-Bases, get_user_db,
+   get_user_manager-Signaturen) sind nicht mehr nötig und werden
+   entfernt. mypy meldet sie als `unused-ignore`, sobald der Hauptfehler
+   verschwindet.
+
+4. **Schema-Drift-Verifikation (D):** Mit den Overrides bleibt das
+   Datenbank-Schema **bit-für-bit identisch**. Verifiziert über:
+   `alembic upgrade head` gegen frische Postgres-DB → `\d "user"` in
+   psql → CREATE TABLE-Output aus der SQLAlchemy-Metadata. Beide
+   stimmen in Spalten (Typ, Nullable, Default), Indizes (`pk_user`,
+   `ix_user_role`, `uq_user_email`, `uq_user_person_id`),
+   Foreign-Keys und Triggern überein. Keine Migration erforderlich.
+
+5. **Test-Verifikation (E):** Komplette Backend-Suite 74/74 grün
+   gegen Postgres 16 + PostGIS 3.4 (M0–M5a.1). RLS-Tests, Auth-Tests,
+   und alle Domain-CRUD-Pfade passieren ohne Anpassungen.
+
+**Konsequenzen:**
+
+- `mypy --strict` ist clean (50 Source-Files, 0 Errors).
+- DoD aus `project-context.md` §7 wieder vollständig erfüllt.
+- Keine `# type: ignore`-Schulden mehr im Auth-Modul.
+- Pattern „Override-Spalten in `if not TYPE_CHECKING`" ist
+  dokumentiert und kann als Vorlage dienen, falls weitere
+  fastapi-users-Erweiterungen (z. B. ein Pfad-B-Audit-Log-Modell)
+  ähnliche Override-Bedürfnisse haben.
+
+**Verworfene Alternativen:**
+
+- B (`# type: ignore[type-var]` an Zeile 20 belassen): hätte den
+  Designmismatch versteckt und den vorhandenen Workaround-Cluster in
+  `app/auth/manager.py` zementiert.
+- C (mypy-per-file-Override für `app/auth/routes.py`): Loch in der
+  `mypy --strict`-Garantie, gilt für jede zukünftige Änderung an der
+  Datei.
+- A ohne Spalten-Overrides: hätte einen impliziten zusätzlichen Index
+  auf `email`, einen anonymen Unique-Constraint, fehlende
+  `server_default`-Werte auf den Boolean-Flags, und UUIDv4 statt
+  UUIDv7 für neue User (Bruch von ADR-018) bedeutet —
+  Schema-Migration plus ADR-Konflikt.
 
 ---
 

--- a/docs/fahrplan.md
+++ b/docs/fahrplan.md
@@ -30,7 +30,7 @@ Status-Marker (gemäß CLAUDE.md Abschnitt 7):
 - **Aktiver Schritt:** M5a (Live-Modus) — Sub-Schritt **M5a.1 [ERLEDIGT] 2026-04-26**
 - **Nächster Schritt:** M5a.2 — Frontend Startseite, Suche, Export-UI
 - **Offene STOPP-Situationen:** keine
-- **Offene Beobachtungen:** mypy `app/auth/routes.py:20` meldet einen vorbestehenden Fehler (Value of type variable "models.UP" of "FastAPIUsers" cannot be "User"). Der Fehler liegt im M2-Modul, ist nicht durch M5a.1 verursacht und wird separat aufgelöst, sobald jemand am Auth-Modul arbeitet (siehe ADR-024 §Konsequenzen).
+- **Offene Beobachtungen:** keine. (Der vorbestehende mypy-Befund in `app/auth/routes.py:20` ist mit ADR-025 behoben: User erbt jetzt von `SQLAlchemyBaseUserTableUUID`, fünf `# type: ignore`-Workarounds in `app/auth/manager.py` entfernt, Schema unverändert, `mypy --strict` clean.)
 
 ## Überblick
 


### PR DESCRIPTION
## Summary

Behebt den seit M2 vorhandenen mypy-Fehler in [app/auth/routes.py:20](backend/app/auth/routes.py:20):

\`\`\`
app/auth/routes.py:20: error: Value of type variable "models.UP" of "FastAPIUsers" cannot be "User"  [type-var]
\`\`\`

`mypy --strict` ist nach diesem Fix wieder vollständig clean (50 Source-Files, 0 Errors). Damit ist die DoD aus [project-context.md:146](docs/project-context.md) auch ohne pre-existing-Befund erfüllt.

## Was sich ändert

### Code

- **[backend/app/models/user.py](backend/app/models/user.py):** `User` erbt zusätzlich von `SQLAlchemyBaseUserTableUUID`. Die fastapi-users-Pflichtspalten (`id`, `email`, `hashed_password`, `is_active`, `is_superuser`, `is_verified`) sind über `if not TYPE_CHECKING:` neu deklariert — zur Laufzeit nutzt SQLAlchemy unsere Overrides (UUIDv7-Default per ADR-018, kein inline `unique=True/index=True` auf email, `server_default` auf den Boolean-Flags), zur Type-Check-Zeit sieht mypy die Plain-Types der Elternklasse, die das `UP`-Protokoll erfüllen.
- **[backend/app/auth/manager.py](backend/app/auth/manager.py):** Fünf `# type: ignore[type-var]`-Kommentare entfernt. Sie waren Workarounds für genau diesen Befund und meldete mypy als `unused-ignore`, sobald der Hauptfehler weg war.

### Doku

- **ADR-025**: Vererbung + Override-Pattern dokumentiert, mit Begründung warum jede der drei alternativen Lösungen (`# type: ignore` belassen, mypy-per-file-Override, Vererbung ohne Spalten-Overrides) abgelehnt wurde.
- **CHANGELOG**: neuer `### Fixed`-Block.
- **fahrplan.md**: „Offene Beobachtungen" zurück auf „keine".

## Schema-Drift

**Keine.** Verifiziert durch:

1. `alembic upgrade head` gegen frische Postgres+PostGIS 16/3.4-DB
2. `\d "user"` in psql (alle 13 Spalten, 4 Indizes, Constraints, FKs, Trigger)
3. `CreateTable(User.__table__).compile(...)` aus der SQLAlchemy-Metadata
4. Alle drei Outputs stimmen bit-für-bit überein

Keine Migration im PR.

## Warum

`SQLAlchemyBaseUserTableUUID` deklariert die Pflichtspalten unter `if TYPE_CHECKING` als Plain-Types und unter `else` als `Mapped[...]`-Columns — genau das Muster, das mypy als Protocol-Erfüllung sieht. Wir spiegeln dieses Muster für unsere Spalten-Overrides, sodass die Vererbung typisch sauber ist *und* unser DB-Schema (UUIDv7, server_defaults, benannte Constraints) unverändert bleibt.

## Test plan

- [x] `uv run ruff check app tests` — clean
- [x] `uv run ruff format --check app tests` — clean
- [x] `uv run mypy app` — **Success: no issues found in 50 source files** (vorher: 1 error)
- [x] `uv run pytest -q` — 74/74 passed (M0–M5a.1)
- [x] Schema-Drift-Vergleich (siehe oben) — keine Drift

## Reihenfolge / Konfliktrisiko

Der Branch baut auf `main` direkt nach Merge von [#6](https://github.com/Paddel87/HC-Map/pull/6) auf. Berührt nur das Auth-Modul (M2-Territorium) plus Doku — keine Überschneidung mit den geplanten M5a.2/.3/.4-Frontend-PRs.

## Fahrplan / ADR

- Fahrplan: M2-Nachzug, vor M5a.2
- Neuer ADR: **ADR-025**

🤖 Generated with [Claude Code](https://claude.com/claude-code)