### PR TITLE
fix(m11-hotfix-009): application-lifecycle Auto-Stop bei Event-Ende (Issue #23, ADR-057)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Bis zum ersten Go-Live (M11) bleibt das Projekt auf `0.0.0`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **M11-HOTFIX-009 — Application-Lifecycle Auto-Stop bei Event-Ende (2026-05-03, Issue [#23](https://github.com/Paddel87/HC-Map/issues/23) Befund 2, ADR-057).**
+  Wenn ein Event beendet wird, werden alle noch laufenden Applications dieses Events automatisch auf den Event-Ende-Zeitstempel gesetzt — Lifecycle-Kaskade ist jetzt konzeptkonform. Greift an drei Server-Pfaden: `POST /api/events/{id}/end` (Live-Modus), `PATCH /api/events/{id}` (Edit-Form) und RxDB-Event-Push (Offline-Reconnect-Fall). Frontend ergänzt um Stop-Button pro aktive Application in der Timeline (kein Umweg mehr über „Event bearbeiten") und um Live-Validation im Edit-Form (Bounds-Verletzungen sind sofort sichtbar, nicht erst nach Submit-Klick). Volle Backend-Suite **258/258** + Frontend-Suite **282/282** grün, End-to-End-Browser-Smoke bestätigt: Event mit zwei laufenden Applications → Event-Ende → beide Applications haben exakt `event.ended_at`-Timestamp.
+
 ### Added
 
 - **M11-HOTFIX-008 — Optionales `event.title`-Feld für Identifikation und Wiederfindung (2026-05-03, Issue [#27](https://github.com/Paddel87/HC-Map/issues/27) Befund 4+5, ADR-056).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Bis zum ersten Go-Live (M11) bleibt das Projekt auf `0.0.0`.
 
 ### Added
 
+- **M11-HOTFIX-008 — Optionales `event.title`-Feld für Identifikation und Wiederfindung (2026-05-03, Issue [#27](https://github.com/Paddel87/HC-Map/issues/27) Befund 4+5, ADR-056).**
+  Events bekommen ein optionales Titel-Feld (max. 120 Zeichen) zur schnellen Wiederfindung im Dashboard und auf der Karte. Backend-Migration `event.title VARCHAR(120) NULL`, RxDB-Schema-Bump v1→v2 mit Migrations-Strategie (alte Docs erhalten `title=null`), neues Eingabefeld in beiden Erfassungs-Forms (Live + Backfill) sowie editierbar in der Bearbeiten-Ansicht. Anzeige als Hauptzeile im Dashboard, prominenter Header im Event-Detail, erste Zeile im Karten-Marker-Popup. Fallback bei NULL: aktuelle Startzeit-/Koordinaten-Darstellung. Volle Backend-Suite **256/256** + Frontend-Suite **282/282** grün, Browser-Smoke bestätigt End-to-End-Pipeline (POST API → DB → RxDB-Sync → alle UI-Stellen).
+
 - **M11-HOTFIX-007 — MapLibre `GeolocateControl` (Fadenkreuz) in Karten-Komponenten (2026-05-03, Issue [#22](https://github.com/Paddel87/HC-Map/issues/22)).**
   Beide Karten-Komponenten ([`frontend/src/components/map/map-view.tsx`](frontend/src/components/map/map-view.tsx) und [`frontend/src/components/map/location-picker-map.tsx`](frontend/src/components/map/location-picker-map.tsx)) zeigen jetzt das MapLibre-Standard-Crosshair-Control unter den Zoom-Buttons oben rechts. Tap zentriert die Karte auf den eigenen GPS-Fix; im `LocationPickerMap` wird zusätzlich der Marker direkt auf die User-Position gesetzt — kein separater zweiter Tap nötig. Operator-Wunsch aus dem RC-3-Mobile-Test auf Nodica1: Pan/Zoom-Aufwand entfällt, gerade wenn Default-Karten-Region weit weg vom aktuellen Standort liegt. Kein neuer Stack-Bestandteil, keine Datenmodell-/API-Änderung; volle Suite **282/282** grün, Browser-Verifikation auf `/map` und `/events/new` bestätigt das Control-DOM.
 

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Numeric,
+    String,
     Text,
     UniqueConstraint,
     func,
@@ -67,6 +68,7 @@ class Event(Base, TimestampMixin, CreatedByMixin, SoftDeleteMixin):
     reveal_participants: Mapped[bool] = mapped_column(
         nullable=False, default=False, server_default="false"
     )
+    title: Mapped[str | None] = mapped_column(String(120), nullable=True)
     note: Mapped[str | None] = mapped_column(Text, nullable=True)
     # ADR-030: updated_at is the RxDB pull cursor → NOT NULL with a server-side
     # default (clock_timestamp matches the set_updated_at trigger from M1).

--- a/backend/app/routes/events.py
+++ b/backend/app/routes/events.py
@@ -270,6 +270,7 @@ async def _build_detail(session: AsyncSession, event_id: uuid.UUID, user: User) 
         lat=event.lat,
         lon=event.lon,
         reveal_participants=event.reveal_participants,
+        title=event.title,
         note=event.note,
         legacy_external_ref=event.legacy_external_ref,
         created_by=event.created_by,

--- a/backend/app/schemas/event.py
+++ b/backend/app/schemas/event.py
@@ -17,6 +17,7 @@ class EventBase(BaseModel):
     lat: Decimal = Field(..., ge=Decimal("-90"), le=Decimal("90"))
     lon: Decimal = Field(..., ge=Decimal("-180"), le=Decimal("180"))
     reveal_participants: bool = False
+    title: str | None = Field(default=None, max_length=120)
     note: str | None = None
     legacy_external_ref: str | None = None
 
@@ -37,6 +38,7 @@ class EventStart(BaseModel):
     lon: Decimal = Field(..., ge=Decimal("-180"), le=Decimal("180"))
     recipient_id: uuid.UUID | None = None
     reveal_participants: bool = False
+    title: str | None = Field(default=None, max_length=120)
     note: str | None = None
 
 
@@ -46,6 +48,7 @@ class EventUpdate(BaseModel):
     lat: Decimal | None = Field(default=None, ge=Decimal("-90"), le=Decimal("90"))
     lon: Decimal | None = Field(default=None, ge=Decimal("-180"), le=Decimal("180"))
     reveal_participants: bool | None = None
+    title: str | None = Field(default=None, max_length=120)
     note: str | None = None
     legacy_external_ref: str | None = None
 

--- a/backend/app/services/events.py
+++ b/backend/app/services/events.py
@@ -172,7 +172,9 @@ async def auto_stop_open_applications(
         )
         .values(ended_at=ended_at)
     )
-    return int(result.rowcount or 0)
+    # `result` is a CursorResult for bulk DML, which carries rowcount;
+    # the typed Result[Any] return signature hides that, hence the cast.
+    return int(getattr(result, "rowcount", 0) or 0)
 
 
 async def list_participants(session: AsyncSession, event_id: uuid.UUID) -> Sequence[Person]:

--- a/backend/app/services/events.py
+++ b/backend/app/services/events.py
@@ -59,6 +59,7 @@ async def create_event(
         lat=payload.lat,
         lon=payload.lon,
         reveal_participants=payload.reveal_participants,
+        title=payload.title,
         note=payload.note,
         legacy_external_ref=payload.legacy_external_ref,
         created_by=created_by,
@@ -113,6 +114,7 @@ async def start_event(
         lat=payload.lat,
         lon=payload.lon,
         reveal_participants=payload.reveal_participants,
+        title=payload.title,
         note=payload.note,
         created_by=created_by,
     )

--- a/backend/app/services/events.py
+++ b/backend/app/services/events.py
@@ -6,9 +6,10 @@ import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.application import Application
 from app.models.event import Event, EventParticipant
 from app.models.person import Person
 from app.schemas.event import EventCreate, EventStart, EventUpdate
@@ -83,9 +84,14 @@ async def update_event(
     event: Event,
     payload: EventUpdate,
 ) -> Event:
+    was_open = event.ended_at is None
     for field, value in payload.model_dump(exclude_unset=True).items():
         setattr(event, field, value)
     await session.flush()
+    # ADR-057: when ended_at transitions from null to non-null, cascade
+    # to any still-running applications.
+    if was_open and event.ended_at is not None:
+        await auto_stop_open_applications(session, event.id, event.ended_at)
     await session.refresh(event)
     return event
 
@@ -129,12 +135,44 @@ async def start_event(
 
 
 async def end_event(session: AsyncSession, event: Event) -> Event:
-    """Set ``ended_at = now()`` if not already set (idempotent)."""
+    """Set ``ended_at = now()`` if not already set (idempotent).
+
+    Also auto-stops every still-running Application of the event by
+    setting their ``ended_at`` to the same timestamp (ADR-057). This
+    keeps the lifecycle cascade consistent — a finished event must
+    not have running children.
+    """
     if event.ended_at is None:
-        event.ended_at = datetime.now(tz=UTC)
+        ended_at = datetime.now(tz=UTC)
+        event.ended_at = ended_at
         await session.flush()
+        await auto_stop_open_applications(session, event.id, ended_at)
         await session.refresh(event)
     return event
+
+
+async def auto_stop_open_applications(
+    session: AsyncSession,
+    event_id: uuid.UUID,
+    ended_at: datetime,
+) -> int:
+    """Close every running, non-deleted Application of the event (ADR-057).
+
+    Returns the number of Application rows that were updated. Idempotent:
+    if no Applications are running, the UPDATE matches zero rows and
+    nothing is changed. ``updated_at`` is left to the database trigger
+    (``set_updated_at``, see M1 migration) so the RxDB cursor advances.
+    """
+    result = await session.execute(
+        update(Application)
+        .where(
+            Application.event_id == event_id,
+            Application.ended_at.is_(None),
+            Application.is_deleted.is_(False),
+        )
+        .values(ended_at=ended_at)
+    )
+    return int(result.rowcount or 0)
 
 
 async def list_participants(session: AsyncSession, event_id: uuid.UUID) -> Sequence[Person]:

--- a/backend/app/sync/schemas.py
+++ b/backend/app/sync/schemas.py
@@ -37,6 +37,7 @@ class EventDoc(BaseModel):
     lon: float = Field(ge=-180, le=180)
     legacy_external_ref: str | None = None
     reveal_participants: bool = False
+    title: str | None = Field(default=None, max_length=120)
     note: str | None = None
     created_by: uuid.UUID | None = None
     created_at: datetime

--- a/backend/app/sync/services.py
+++ b/backend/app/sync/services.py
@@ -207,10 +207,17 @@ async def push_events(
         if conflict is not None:
             conflicts.append(conflict)
             continue
+        was_open = existing.ended_at is None
         _apply_event_update(existing, new_doc)
         try:
             async with session.begin_nested():
                 await session.flush()
+                # ADR-057: cascade auto-stop to running applications when
+                # the event transitions from open to ended.
+                if was_open and existing.ended_at is not None:
+                    from app.services.events import auto_stop_open_applications
+
+                    await auto_stop_open_applications(session, existing.id, existing.ended_at)
         except (IntegrityError, ProgrammingError):
             # Savepoint already rolled back; outer TX still alive. The local
             # ORM state is dirty but we abandon this item.

--- a/backend/app/sync/services.py
+++ b/backend/app/sync/services.py
@@ -233,6 +233,7 @@ async def _insert_event_or_conflict(
         lon=Decimal(str(new_doc.lon)),
         legacy_external_ref=new_doc.legacy_external_ref,
         reveal_participants=new_doc.reveal_participants,
+        title=new_doc.title,
         note=new_doc.note,
         created_by=user.id,
         is_deleted=new_doc.deleted,
@@ -282,6 +283,7 @@ def _apply_event_update(existing: Event, new_doc: EventDoc) -> None:
     if existing.ended_at is None and new_doc.ended_at is not None:
         existing.ended_at = new_doc.ended_at
     # LWW.
+    existing.title = new_doc.title
     existing.note = new_doc.note
     existing.reveal_participants = new_doc.reveal_participants
     existing.legacy_external_ref = new_doc.legacy_external_ref
@@ -493,6 +495,7 @@ def _event_to_doc(row: Event) -> EventDoc:
         lon=float(row.lon),
         legacy_external_ref=row.legacy_external_ref,
         reveal_participants=row.reveal_participants,
+        title=row.title,
         note=row.note,
         created_by=row.created_by,
         created_at=row.created_at,

--- a/backend/migrations/versions/20260503_1800_event_title.py
+++ b/backend/migrations/versions/20260503_1800_event_title.py
@@ -1,0 +1,33 @@
+"""Add optional ``event.title`` column (ADR-056, M11-HOTFIX-008).
+
+Adds a nullable VARCHAR(120) column for short event identifiers
+(Issue #27 Befund 4+5). Existing rows default to NULL — UI falls back
+to the previous start-time/coordinate display when the field is unset.
+
+Revision ID: 20260503_1800_event_title
+Revises: 20260501_1200_legacy_ref
+Create Date: 2026-05-03 18:00:00 UTC
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260503_1800_event_title"
+down_revision: str | None = "20260501_1200_legacy_ref"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "event",
+        sa.Column("title", sa.String(length=120), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("event", "title")

--- a/backend/tests/test_events_live_api.py
+++ b/backend/tests/test_events_live_api.py
@@ -124,3 +124,57 @@ async def test_end_event_unknown_id_returns_404(
         "/api/events/00000000-0000-0000-0000-000000000000/end",
     )
     assert resp.status_code == 404
+
+
+async def test_end_event_auto_stops_running_applications(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """ADR-057: ending an event must cascade to running applications."""
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    start = await post_with_csrf(client, csrf, "/api/events/start", json={"lat": "0", "lon": "0"})
+    event_id = start.json()["id"]
+    # Two applications: one will be ended manually before the event ends,
+    # the other stays running and must be auto-stopped.
+    app1 = await post_with_csrf(client, csrf, f"/api/events/{event_id}/applications/start", json={})
+    app1_id = app1.json()["id"]
+    await post_with_csrf(client, csrf, f"/api/applications/{app1_id}/end")
+    app2 = await post_with_csrf(client, csrf, f"/api/events/{event_id}/applications/start", json={})
+    app2_id = app2.json()["id"]
+
+    end = await post_with_csrf(client, csrf, f"/api/events/{event_id}/end")
+    assert end.status_code == 200, end.text
+    event_ended_at = end.json()["ended_at"]
+    assert event_ended_at is not None
+
+    # Both applications must now be ended; app2 should match the event's
+    # ended_at timestamp (auto-stop), app1 keeps its earlier ended_at.
+    app1_after = await client.get(f"/api/applications/{app1_id}")
+    app2_after = await client.get(f"/api/applications/{app2_id}")
+    assert app1_after.json()["ended_at"] is not None
+    assert app2_after.json()["ended_at"] == event_ended_at
+
+
+async def test_patch_event_with_ended_at_auto_stops_applications(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """ADR-057: PATCH /api/events with ``ended_at`` must also cascade."""
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    start = await post_with_csrf(client, csrf, "/api/events/start", json={"lat": "0", "lon": "0"})
+    event_id = start.json()["id"]
+    app = await post_with_csrf(client, csrf, f"/api/events/{event_id}/applications/start", json={})
+    app_id = app.json()["id"]
+
+    patch_payload = {"ended_at": datetime.now(tz=UTC).isoformat()}
+    patch = await client.patch(
+        f"/api/events/{event_id}",
+        json=patch_payload,
+        headers={"X-CSRF-Token": csrf},
+    )
+    assert patch.status_code == 200, patch.text
+    event_ended_at = patch.json()["ended_at"]
+    assert event_ended_at is not None
+
+    app_after = await client.get(f"/api/applications/{app_id}")
+    assert app_after.json()["ended_at"] is not None

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5173,4 +5173,85 @@ Bestehende lokale RxDB-Docs in IndexedDB werden bei nächstem Mount automatisch 
 
 ---
 
+## ADR-057 — Application-Lifecycle: Auto-Stop bei Event-Ende + Stop-Button pro Application (Issue #23 Befund 2)
+
+**Status:** Accepted
+**Datum:** 2026-05-03
+**Freigabe:** 2026-05-03 (Patrick — Variante A, Reihenfolge-Freigabe nach Operator-Befundbericht-Triage)
+**Kategorie:** §4.5 API-Vertrags-Änderung (zusätzliche Server-Side-Effekte beim Event-Ende: Auto-Cascade auf laufende Applications). Sekundär §4.4 (Service-Layer-Logik im Sync-Pfad).
+**Vorgänger:** [ADR-011](./decisions.md) (Live-Modus Lifecycle), [ADR-029](./decisions.md) (RxDB-Replication / FWW vs LWW), [ADR-038](./decisions.md) (Event-Detail-View), [ADR-039](./decisions.md) (Backfill-Validation), [ADR-040](./decisions.md) (Edit-UI).
+
+### Kontext
+
+Issue [#23](https://github.com/Paddel87/HC-Map/issues/23) Befund 2 (Operator-Feldtest, RC-3-Phase Nodica1) — drei zusammengehörige Beobachtungen:
+
+- **2a:** Ein Live-Event wird beendet, aber zugehörige Applications bleiben offen-laufend. Der Container-Event ist terminiert, die Children sind es nicht — inkonsistent gegenüber der erwartbaren Lifecycle-Kaskade.
+- **2b:** Im laufenden Live-Event hat eine einzelne Application keinen sichtbaren Stop-Button. Der einzige Weg zum Beenden geht über „Event bearbeiten" + manuelle Ende-Datum-Eingabe — fehleranfällig (siehe 2c).
+- **2c:** Backend-Validatoren („Application endet nach dem Event-Ende", „Application-Ende liegt vor dem Start") greifen korrekt, sind aber UX-Sackgassen. Wenn das Frontend dieselbe Logik kennt, sollte es sie verwenden, statt den User in eine Backend-Validator-Kollision laufen zu lassen.
+
+### Entscheidungen
+
+**A. Backend Auto-Stop (Variante A aus dem Triage-Block).**
+
+Drei Alternativen wurden Patrick vorgelegt:
+- **A — Backend-Auto-Stop + Stop-Button + Frontend-Pre-Submit-Hint.** Beim Event-Ende setzt der Service alle nicht-beendeten Applications dieses Events transaktional auf `ended_at = event.ended_at`.
+- **B — Frontend-only Auto-Stop.** Beim Event-Beenden iteriert das Frontend über offene Applications und schickt einzelne PATCH-Requests. Verworfen: Race-Conditions bei Offline/Reconnect, mehrere Requests statt einer Transaktion.
+- **C — Nur Stop-Button + Pre-Submit-Hint, kein Auto-Stop.** Verworfen: Befund 2a (Konzeptbruch durch Lifecycle-Inkonsistenz) bleibt bestehen.
+
+**Patrick wählt A.** Begründung: Auto-Stop ist die einzige Variante, die die Lifecycle-Kaskade konzeptkonform macht — ohne sie bleibt der Datenstand inkonsistent (beendetes Event mit laufenden Applications). Backend-Touch ist klein.
+
+**B. Server-Side Auto-Stop an drei Code-Pfaden.**
+
+Auto-Stop muss überall greifen, wo `event.ended_at` von `null` auf `not null` wechselt:
+
+1. **`POST /api/events/{id}/end`** ([`backend/app/services/events.py:end_event`](../backend/app/services/events.py)) — Live-Modus-Beenden. Direkter Trigger.
+2. **`PATCH /api/events/{id}`** ([`backend/app/services/events.py:update_event`](../backend/app/services/events.py)) — Edit-Form setzt `ended_at` nachträglich (FWW-only-when-null, ADR-040 §C).
+3. **RxDB-Push** ([`backend/app/sync/services.py:_apply_event_update`](../backend/app/sync/services.py)) — Frontend-RxDB pusht ein Event mit `ended_at != null`.
+
+Alle drei Pfade rufen einen neuen Helper `auto_stop_open_applications(session, event_id, ended_at)` auf, der per UPDATE alle Application-Rows im Event mit `ended_at IS NULL AND is_deleted=false` auf den übergebenen Zeitstempel setzt. Transaktional Teil derselben Session — entweder beide Writes (Event + Children) oder keiner.
+
+**C. Idempotenz und FWW-Kompatibilität.**
+
+- **Idempotenz:** Wenn das Event bereits `ended_at` hat, ändert sich nichts. Der Helper läuft trotzdem, hat aber leere Working-Set (keine offenen Applications mehr).
+- **FWW-Kompatibilität:** Application's `ended_at` ist bisher LWW-frei (kein FWW-Constraint im Sync-Service). Der Auto-Stop überschreibt also keinen vom User gewollten späteren `ended_at`-Wert — wenn der Operator eine Application explizit später beenden wollte, muss er sie *vor* dem Event-Ende beenden.
+
+**D. Frontend: Stop-Button pro laufende Application.**
+
+In [`frontend/src/components/event/event-detail-view.tsx:ApplicationsTimeline`](../frontend/src/components/event/event-detail-view.tsx) bekommt jede aktive Application (`ended_at === null`) einen Stop-Button neben der Timer-Anzeige. Klick ruft denselben Handler wie der bestehende „Aktuelle beenden"-Button im Header (`handleEndApplication(id)`).
+
+Sichtbarkeit: nur wenn `isLive === true` (sonst gibt es keine aktiven Applications) und `endedAt === null`. `data-testid="applications-timeline-stop"` für Tests.
+
+**E. Frontend: Pre-Submit-Hint im Edit-Form.**
+
+Der bestehende [`validateBackfill`](../frontend/src/lib/event-backfill-validation.ts)-Helper liefert bereits `bounds`-Errors für „Application endet nach dem Event-Ende". Im [`event-edit-form.tsx`](../frontend/src/components/event/event-edit-form.tsx) wird die Validierung **bereits beim Tippen** (statt erst beim Submit) ausgewertet, wenn der User ein `ended_at`-Feld editiert. Der Hint erscheint inline am betroffenen Feld, der Submit-Pfad nutzt denselben Validator. Damit muss der Operator nicht erst submit klicken, um die Backend-Validator-Meldung zu sehen — der Konflikt wird sichtbar, sobald der Wert getippt ist.
+
+Implementiert über `useMemo` auf den aktuellen Form-State, der validateBackfill mit den lokalen Werten aufruft und die Errors anzeigt. Submit nutzt dieselben `errors` als Block-Bedingung.
+
+**F. Out-of-Scope (nicht Teil dieses ADR).**
+
+- **Auto-Restart:** Wenn ein Admin ein Event aus dem Soft-Delete restored (ended_at bleibt erhalten), werden Applications nicht „auto-resumed". Restore ist bereits Admin-only, manuelle Korrektur erlaubt.
+- **Auto-Stop im Live-Modus „Neue Application"-Trigger:** Wenn der Operator eine zweite Application startet während die erste läuft, beendet das die erste *nicht* automatisch. Multi-Active ist explizit erlaubt (parallele Restraints).
+- **Audit-Log für Auto-Stop:** Bisher kein dediziertes Audit (kein Audit-Log-System im Repo). Falls später eingeführt, würde Auto-Stop ein Audit-Event auslösen.
+- **Migrations-Daten-Reparatur:** Bestehende inkonsistente Rows (beendete Events mit laufenden Applications) werden *nicht* automatisch repariert. Der Operator kann Edit-Form nutzen.
+
+### Verworfene Alternativen
+
+- **Variante B (Frontend-only Auto-Stop).** Race-Conditions, mehrere Requests statt Transaktion, schwierig bei Offline/Reconnect-Replay.
+- **Variante C (nur Stop-Button + Hint, kein Auto-Stop).** Operator-Befund 2a (Lifecycle-Kaskade) bleibt unbehoben.
+- **Auto-Restart bei Event-Restore.** Operator-Erwartung wäre uneindeutig; manuelle Korrektur ist sicherer.
+
+### Folgearbeit
+
+- **M11-HOTFIX-009** (Fahrplan-Eintrag): Implementierung dieser ADR (Helper, drei Service-Pfade, Stop-Button, Edit-Form-Live-Validation, Tests).
+- **#23 Befund 2 schließen** nach Operator-Verifikation auf Production (Live-Event mit zwei Applications anlegen, Event beenden, beide Applications auf den Event-Ende-Zeitstempel gesetzt).
+
+### Referenzen
+
+- [Issue #23 — Operator-Befundbericht I Befund 2](https://github.com/Paddel87/HC-Map/issues/23)
+- [ADR-011 — Live-Modus Lifecycle](./decisions.md)
+- [ADR-029 — RxDB-Replication FWW vs LWW](./decisions.md)
+- Code-Stellen: [`backend/app/services/events.py`](../backend/app/services/events.py), [`backend/app/services/applications.py`](../backend/app/services/applications.py), [`backend/app/sync/services.py`](../backend/app/sync/services.py), [`frontend/src/components/event/event-detail-view.tsx`](../frontend/src/components/event/event-detail-view.tsx), [`frontend/src/components/event/event-edit-form.tsx`](../frontend/src/components/event/event-edit-form.tsx)
+
+---
+
 **Hinweis zur Initialisierungs-Entscheidung:** Die initiale Anpassung der Vorlagen-Dokumente an HC-Map-Komplexität ist in **ADR-009 (Vorgehensmodell: Vision-driven Scoping vor Code)** dokumentiert. Diese ADR übernimmt die Funktion, die in der generischen Vorlage für ADR-001 vorgesehen war.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5080,4 +5080,97 @@ Der alte `/admin/login`-Redirect entfällt; `/admin/login` ist nun eine Frontend
 
 ---
 
+## ADR-056 — Optionales `event.title`-Feld für Identifikation und Wiederfindung (Issue #27 Befund 4+5)
+
+**Status:** Accepted
+**Datum:** 2026-05-03
+**Freigabe:** 2026-05-03 (Patrick — Variante A, Reihenfolge-Freigabe nach Operator-Befundbericht-II-Triage)
+**Kategorie:** §4.4 Datenmodell-Änderung (neue Spalte am Event-Modell, RxDB-Schema-Bump v1→v2).
+**Vorgänger:** [ADR-029](./decisions.md#adr-029--rxdb-replication-protokoll) (Sync-Protokoll), [ADR-030](./decisions.md#adr-030--soft-delete-und-cursor) (Cursor + Soft-Delete), [ADR-031](./decisions.md#adr-031--rxdb-json-schema-vs-pydantic-drift-test) (Schema-Drift-Test), [ADR-050](./decisions.md#adr-050--m9-w3w-migration-verworfen-eventw3w_legacy-zu-legacy_external_ref-umgewidmet) (vorheriger Schema-Bump v0→v1).
+
+### Kontext
+
+Issue [#27](https://github.com/Paddel87/HC-Map/issues/27) Befund 4 (Operator-Feldtest, RC-3-Phase Nodica1): Events haben kein Titel-/Bezeichnungs-Feld. Im Erfassungs-Workflow gibt es nur GPS + Startzeit + optionale Notiz. Folge:
+
+- **Dashboard:** Events erscheinen mit Startzeit + Koordinaten — schwer voneinander zu unterscheiden, gerade bei mehreren Events am gleichen Tag/Ort.
+- **Karten-Marker (Befund 5):** Punkte zeigen nur Koordinaten + Zeitstempel — visuell „kryptische Zahlen", keine Schnell-Identifikation.
+- **Wiederfindung:** ohne Titel kein mentaler Anker („Konzert in Bremen"), nur exakte Zeit/Ort als Suchschlüssel.
+
+Das `note`-Feld eignet sich als Workaround nicht — es ist semantisch für längere Beobachtungen (Verlauf, Kontext, Stimmung) und in Listen-Ansichten ungekürzt unbrauchbar.
+
+### Entscheidungen
+
+**A. Optionales `title`-Feld auf `event` (Variante A aus dem Triage-Block).**
+
+Drei Alternativen wurden Patrick im Triage-Block vorgelegt:
+- **A — Optionales `title VARCHAR(120) NULL` auf Event.** Anzeige: Dashboard-Hauptzeile, Karten-Marker-Tooltip/Label, Edit-Header. Fallback bei NULL: aktuelle Darstellung (Startzeit + Koordinaten).
+- **B — Status quo.** Operator nutzt `note`-Feld als Workaround. Verworfen: `note` ist für längere Beobachtungen, in Listen-Ansichten unbrauchbar.
+- **C — Synthetisch im Frontend** aus `note`-First-Line. Verworfen: keine echte Identifier-Semantik, nicht editierbar als Identifikator, vermischt zwei orthogonale Felder.
+
+**Patrick wählt A.** Begründung: niedrigschwellige Migration (eine Spalte, nullable, kein Constraint), löst Befund 4 + 5 + die „Wiederfindung"-Sorge aus Befund 6 ein Stück weit. Wirkt sich an drei UI-Stellen aus (Dashboard, Karten-Marker, Edit-Form), klar abgrenzbar.
+
+**B. Schema-Form: `title VARCHAR(120)`, NULL erlaubt, kein Default.**
+
+- `VARCHAR(120)` deckt typische Bezeichnungen ab (Operator-Vorschlag war ~80 Zeichen, mit Puffer auf 120 für Mehrteiler wie „Konzert in Bremen — Halle 7").
+- Nullable=True: Operator kann das Feld leer lassen → Fallback auf bestehende Darstellung (Startzeit + Koordinaten). **Keine Pflicht** — sonst wäre der Live-Modus mit Schnell-Erfassung „Tap → Standort → Start" gestört.
+- Kein Server-Default — `NULL` ist die explizite Markierung „nicht gesetzt".
+- Kein Volltext-Index initial — Such-Use-Case kommt erst mit M5c-NACH/M16; falls Volltextsuche nötig, kann der `note`-FTS-Index aus M3 erweitert werden (eigener Folge-ADR).
+
+**C. RxDB-Schema-Bump v1 → v2 mit Migrations-Strategie.**
+
+`frontend/src/lib/rxdb/schemas/event.schema.json` bekommt `version: 2` und ein neues `title`-Property (`type: ["string", "null"]`, `maxLength: 120`). `frontend/src/lib/rxdb/database.ts` ergänzt:
+
+```typescript
+migrationStrategies: {
+  1: ...,  // v0 → v1 aus ADR-050
+  2: (doc) => ({ ...doc, title: null }),  // v1 → v2: Default null
+}
+```
+
+Bestehende lokale RxDB-Docs in IndexedDB werden bei nächstem Mount automatisch transformiert. Backend-DB-Migration setzt `title=NULL` für alle bestehenden Rows, was identisch ist — keine Daten-Reparatur nötig.
+
+**D. UI-Stellen.**
+
+- **Erfassungs-Forms** (`event-create-form.tsx`, `event-backfill-form.tsx`): neues optionales Eingabefeld „Titel" (`<input maxLength={120}>`), positioniert vor dem `Notiz`-Block.
+- **Edit-Form** (`event-edit-form.tsx`): `title` als editierbares Feld in der bestehenden Editable-Felder-Liste (analog `note`).
+- **Detail-View** (`event-detail-view.tsx`): `title` als Page-Header (oben prominent), Fallback auf bisherige Startzeit-Darstellung wenn NULL.
+- **Dashboard** (`(protected)/page.tsx`): `title` als Hauptzeile (statt/zusätzlich zur Startzeit). Fallback wie oben.
+- **MapView Popup** (`map-view.tsx`): `title` als Erste Zeile im Popup, Fallback Startzeit.
+
+**E. Sync-Protokoll und Backend-Schemas.**
+
+- `backend/app/sync/schemas.py` — `EventDoc.title: str | None = None`.
+- `backend/app/sync/services.py` — `title` durchreichen analog `note`.
+- `backend/app/schemas/event.py` — `EventBase.title`, `EventStart.title`, `EventUpdate.title`. LWW-Verhalten analog `note` (ADR-029).
+- `backend/tests/test_rxdb_schema_drift.py` läuft automatisch mit, sobald JSON-Schema und Pydantic synchron sind.
+
+**F. Out-of-Scope (nicht Teil dieses ADR).**
+
+- **Volltextsuche über `title`:** kommt mit M16-Tags-Suche oder einem expliziten Folge-ADR.
+- **Karten-Marker-Cluster mit Titel-Aggregation** (Befund 5 weitergehend): aktuell zeigt der Cluster nur die Anzahl. Titel-Tooltip beim Tap auf einzelnen Marker reicht für RC-3.
+- **Validierung gegen leere/Whitespace-only Titel**: trim auf Frontend-Seite, Backend akzeptiert NULL = leer (kein Constraint nötig).
+- **Migration bestehender `note`-First-Lines in `title`:** verworfen (Variante C-Reste). Operator pflegt manuell wenn gewünscht.
+
+### Verworfene Alternativen
+
+- **Variante B (Status quo).** Operator-Befund ist konkret und nicht hypothetisch; Workaround über `note` bricht die Listen-Ansichten.
+- **Variante C (Frontend-synthetisch aus `note`-First-Line).** Vermischt zwei semantisch verschiedene Felder, nicht-editierbar als Identifier, und der Cursor-basierte RxDB-Sync würde die Title-Anzeige nicht reaktiv aktualisieren.
+- **`title NOT NULL` mit Pflicht.** Verworfen: bricht Live-Modus-Schnellerfassung („Tap → Standort → Start").
+- **Längere `VARCHAR`-Limits (255, 500).** Verworfen: Titel ist Identifier, kein Beschreibungstext (das ist `note`). 120 Zeichen reichen für die typischen Operator-Use-Cases.
+
+### Folgearbeit
+
+- **M11-HOTFIX-008** (Fahrplan-Eintrag): Implementierung dieser ADR (Migration, Backend-Modell + Schemas, RxDB-Schema-Bump, fünf UI-Stellen, Tests).
+- **#27 Befund 6 (Wiederfindung):** weiterhin offen, gehört zu M5c-NACH/M16 — Filter/Suche-Implementierung erhält durch `title` eine sinnvolle zusätzliche Such-Dimension.
+
+### Referenzen
+
+- [Issue #27 — Operator-Befundbericht II Befund 4+5](https://github.com/Paddel87/HC-Map/issues/27)
+- [ADR-029 — RxDB-Replication-Protokoll](./decisions.md#adr-029--rxdb-replication-protokoll)
+- [ADR-031 — RxDB-JSON-Schema vs Pydantic Drift-Test](./decisions.md#adr-031--rxdb-json-schema-vs-pydantic-drift-test)
+- [ADR-050 — Vorheriger Schema-Bump v0→v1 (Pattern-Vorlage)](./decisions.md#adr-050--m9-w3w-migration-verworfen-eventw3w_legacy-zu-legacy_external_ref-umgewidmet)
+- Code-Stellen: [`backend/app/models/event.py`](../backend/app/models/event.py), [`backend/app/sync/schemas.py`](../backend/app/sync/schemas.py), [`frontend/src/lib/rxdb/schemas/event.schema.json`](../frontend/src/lib/rxdb/schemas/event.schema.json), [`frontend/src/lib/rxdb/database.ts`](../frontend/src/lib/rxdb/database.ts)
+
+---
+
 **Hinweis zur Initialisierungs-Entscheidung:** Die initiale Anpassung der Vorlagen-Dokumente an HC-Map-Komplexität ist in **ADR-009 (Vorgehensmodell: Vision-driven Scoping vor Code)** dokumentiert. Diese ADR übernimmt die Funktion, die in der generischen Vorlage für ADR-001 vorgesehen war.

--- a/docs/fahrplan.md
+++ b/docs/fahrplan.md
@@ -134,6 +134,7 @@ Jede Phase besteht aus nummerierten Meilensteinen (M0, M1, …). Innerhalb einer
 | 1 MVP   | M11-HOTFIX-005 | └─ Defense-in-Depth `BACKEND_INTERNAL_URL` als Image-ENV-Default (Issue #19) | [ERLEDIGT] 2026-05-02 |
 | 1 MVP   | M11-HOTFIX-006 | └─ SQLAdmin auf `/sqladmin/` umziehen (Issue #19, ADR-055) | [ERLEDIGT] 2026-05-03 |
 | 1 MVP   | M11-HOTFIX-007 | └─ MapLibre `GeolocateControl` in Karten-Komponenten (Issue #22) | [ERLEDIGT] 2026-05-03 |
+| 1 MVP   | M11-HOTFIX-008 | └─ Optionales `event.title`-Feld (Issue #27 Befund 4+5, ADR-056) | [ERLEDIGT] 2026-05-03 |
 | 2 Konso.| M12         | Self-Hosted Tileserver                           | [OFFEN]     |
 | 2 Konso.| M13         | Backup-Härtung & Restore-Tests                   | [OFFEN]     |
 | 2 Konso.| M14         | Monitoring & Alerting                            | [OFFEN]     |
@@ -2103,6 +2104,57 @@ Höchste Wahrscheinlichkeit: `BACKEND_INTERNAL_URL` ist im Frontend-Container ni
 - Verwandt: [#15](https://github.com/Paddel87/HC-Map/issues/15) (gleiche Wurzel-Hypothese), [ADR-053 §A/§C/§F](./decisions.md#adr-053--frontend-ssr-backend-adressierung-im-production-container-netz) (etabliertes Mechanismus, jetzt zusätzlich im Image gepinnt).
 - Operator-Kontext: Folge der Begehung auf Nodica1 mit `:rc` nach M11-HOTFIX-001-Pull; lokale Repro grün, Production-Verifikation steht aus.
 - Folge: HOTFIX-005 hat Hypothese 1 (SSR-Backend-URL) gehärtet, traf aber den eigentlichen Bug nicht — der ist Reverse-Proxy-Routing-Konflikt, gelöst in M11-HOTFIX-006.
+
+---
+
+### M11-HOTFIX-008 — Optionales `event.title`-Feld (Issue #27 Befund 4+5, ADR-056)
+
+**Status:** `[ERLEDIGT]` 2026-05-03 — Owner-Freigabe von Patrick im RC-3-Triage-Block (Variante A); ADR-056 `Accepted`. Branch `claude/m11-hotfix-008-event-title` gestackt auf PR [#28](https://github.com/Paddel87/HC-Map/pull/28).
+
+**Problem:** Issue [#27](https://github.com/Paddel87/HC-Map/issues/27) Befund 4+5 (Operator-Feldtest, RC-3-Phase Nodica1): Events haben kein Titel-/Bezeichnungs-Feld. Dashboard und Karten-Marker zeigen nur Startzeit + GPS-Koordinaten — schwer voneinander zu unterscheiden, keine Schnell-Identifikation. `note`-Workaround bricht Listen-Ansichten.
+
+**Deliverables (alle erledigt):**
+- **ADR-056** (`Accepted`) in [`docs/decisions.md`](./decisions.md): Variante A (`title VARCHAR(120) NULL` auf Event), B/C verworfen, fünf Out-of-Scope-Punkte.
+- **Backend-Migration** [`backend/migrations/versions/20260503_1800_event_title.py`](../backend/migrations/versions/20260503_1800_event_title.py): `add_column` + `drop_column` (transaktional, rückwärtskompatibel).
+- **Backend-Modell** [`backend/app/models/event.py`](../backend/app/models/event.py): `title: Mapped[str | None] = mapped_column(String(120), nullable=True)`.
+- **Backend-Pydantic** [`backend/app/schemas/event.py`](../backend/app/schemas/event.py): `title` in `EventBase`/`EventStart`/`EventUpdate` (`max_length=120`).
+- **Backend-Sync** [`backend/app/sync/schemas.py`](../backend/app/sync/schemas.py) + [`backend/app/sync/services.py`](../backend/app/sync/services.py): `EventDoc.title`, Insert/Update-LWW + `_event_to_doc`-Reverse durchgereicht (analog `note`).
+- **Backend-Service** [`backend/app/services/events.py`](../backend/app/services/events.py): `create_event` + `start_event` reichen `payload.title` durch. `update_event` greift via `model_dump(exclude_unset=True)`.
+- **Backend-Route** [`backend/app/routes/events.py`](../backend/app/routes/events.py): `_build_detail`-Helper um `title=event.title` ergänzt (Bug entdeckt + gefixt während Browser-Smoke — POST gab `null` zurück, weil das manuelle EventDetail-Construct `title` nicht durchschleifte).
+- **RxDB-Schema-Bump v1→v2** [`frontend/src/lib/rxdb/schemas/event.schema.json`](../frontend/src/lib/rxdb/schemas/event.schema.json): `version: 2`, neues `title`-Property (`type: ["string", "null"]`, `maxLength: 120`).
+- **RxDB-Migration-Strategie** [`frontend/src/lib/rxdb/database.ts`](../frontend/src/lib/rxdb/database.ts): `migrationStrategies[2] = (doc) => ({ ...doc, title: null })`. Browser-Smoke bestätigt: alte v1-IndexedDB-Stores werden in neue v2-Stores migriert.
+- **Frontend-Types** [`frontend/src/lib/rxdb/types.ts`](../frontend/src/lib/rxdb/types.ts), [`frontend/src/lib/types.ts`](../frontend/src/lib/types.ts), [`frontend/src/lib/map/event-marker-data.ts`](../frontend/src/lib/map/event-marker-data.ts): `title: string | null` in `EventDocType`/`EventListItem`/`MappableEvent`/`EventStartPayload`.
+- **Frontend-UI** (5 Stellen):
+  - [`event-create-form.tsx`](../frontend/src/components/event/event-create-form.tsx): neue „Titel (optional)"-Card vor Notiz, `<input maxLength={120}>` mit Trim auf null.
+  - [`event-backfill-form.tsx`](../frontend/src/components/event/event-backfill-form.tsx): selbiges Pattern, `data-testid="event-backfill-title"`.
+  - [`event-edit-form.tsx`](../frontend/src/components/event/event-edit-form.tsx): editierbares Feld in Editable-Felder-Liste (LWW analog `note`), Diff-Logik.
+  - [`event-detail-view.tsx`](../frontend/src/components/event/event-detail-view.tsx): `title` als Page-Header (oben prominent, `data-testid="event-detail-title"`), Fallback auf bisherige Startzeit-Darstellung wenn NULL. `MergedEvent.title` durchgereicht.
+  - [`(protected)/page.tsx`](../frontend/src/app/(protected)/page.tsx) Dashboard: `title` als Hauptzeile, Datum + Koordinaten als Meta. Fallback wenn NULL.
+  - [`map-view.tsx`](../frontend/src/components/map/map-view.tsx) `EventPopupContent`: `title` als erste Zeile (`data-testid="map-event-popup-title"`), Datum darunter.
+- [`(protected)/events/[id]/page.tsx`](../frontend/src/app/(protected)/events/[id]/page.tsx): `synthesizeFromRxdb` reicht `title` durch (sonst TS2741 für `EventDetail`).
+
+**Verifikation:**
+- `uv run pytest -q` → **256/256 grün** (gleicher Count wie vor Hotfix; `test_rxdb_schema_drift.py` bestätigt JSON-Schema ↔ Pydantic-Sync automatisch).
+- `uv run ruff check app tests` → All checks passed.
+- `uv run ruff format --check app tests migrations` → 113 files already formatted.
+- `uv run mypy --strict app/models/event.py app/schemas/event.py app/sync/schemas.py app/sync/services.py app/services/events.py` → Success: no issues found.
+- `pnpm typecheck` → clean.
+- `pnpm lint` → clean.
+- `pnpm test` → **282/282 grün**.
+- `pnpm prettier --check` (per-file für die 12 berührten Frontend-Dateien) → clean.
+- **Browser-Verifikation** (Dev-Stack lokal hochgefahren via `preview_*`, Alembic-Migration angewandt, eingeloggt als Admin):
+  - POST `/api/events` mit `title: "Konzert in Bremen"` → 201, Response enthält `title` korrekt.
+  - DB-Direkt-Probe (`docker exec ... psql ... SELECT title FROM event`) → `Konzert in Bremen`.
+  - Dashboard `/`: Title als Hauptzeile, Datum + Koordinaten als Meta-Sub-Zeile.
+  - Detail-View `/events/{id}`: `[data-testid="event-detail-title"]` zeigt „Konzert in Bremen" als prominenten Header.
+  - Edit-Form `/events/{id}/edit`: `[data-testid="event-edit-title"]` mit `value="Konzert in Bremen"`, `maxLength=120`.
+  - MapView `/map`: Status-Bar zeigt „2 Events sichtbar"; IndexedDB-Direktinspektion bestätigt RxDB-v2-Schema-Migration (Datenbank `rxdb-dexie-hcmap--2--events` enthält beide Events mit `title` befüllt).
+
+**Bezug:**
+- Issue: [#27 — Operator-Befundbericht II Befund 4+5](https://github.com/Paddel87/HC-Map/issues/27) (Event-Titel + Karten-Marker-Label).
+- ADR: [ADR-056 — Optionales `event.title`-Feld](./decisions.md#adr-056--optionales-eventtitle-feld-für-identifikation-und-wiederfindung-issue-27-befund-45) (Status `Accepted`).
+- Vorgänger-ADRs: [ADR-029](./decisions.md), [ADR-030](./decisions.md), [ADR-031](./decisions.md), [ADR-050](./decisions.md) (Schema-Bump-Pattern).
+- Folge: Operator-Verifikation auf Nodica1 nach RC-4-Tag (oder Stack-Merge), `#27` bleibt als Sammelbericht-Anker offen.
 
 ---
 

--- a/docs/fahrplan.md
+++ b/docs/fahrplan.md
@@ -135,6 +135,7 @@ Jede Phase besteht aus nummerierten Meilensteinen (M0, M1, …). Innerhalb einer
 | 1 MVP   | M11-HOTFIX-006 | └─ SQLAdmin auf `/sqladmin/` umziehen (Issue #19, ADR-055) | [ERLEDIGT] 2026-05-03 |
 | 1 MVP   | M11-HOTFIX-007 | └─ MapLibre `GeolocateControl` in Karten-Komponenten (Issue #22) | [ERLEDIGT] 2026-05-03 |
 | 1 MVP   | M11-HOTFIX-008 | └─ Optionales `event.title`-Feld (Issue #27 Befund 4+5, ADR-056) | [ERLEDIGT] 2026-05-03 |
+| 1 MVP   | M11-HOTFIX-009 | └─ Application-Lifecycle Auto-Stop bei Event-Ende (Issue #23 Befund 2, ADR-057) | [ERLEDIGT] 2026-05-03 |
 | 2 Konso.| M12         | Self-Hosted Tileserver                           | [OFFEN]     |
 | 2 Konso.| M13         | Backup-Härtung & Restore-Tests                   | [OFFEN]     |
 | 2 Konso.| M14         | Monitoring & Alerting                            | [OFFEN]     |
@@ -2104,6 +2105,47 @@ Höchste Wahrscheinlichkeit: `BACKEND_INTERNAL_URL` ist im Frontend-Container ni
 - Verwandt: [#15](https://github.com/Paddel87/HC-Map/issues/15) (gleiche Wurzel-Hypothese), [ADR-053 §A/§C/§F](./decisions.md#adr-053--frontend-ssr-backend-adressierung-im-production-container-netz) (etabliertes Mechanismus, jetzt zusätzlich im Image gepinnt).
 - Operator-Kontext: Folge der Begehung auf Nodica1 mit `:rc` nach M11-HOTFIX-001-Pull; lokale Repro grün, Production-Verifikation steht aus.
 - Folge: HOTFIX-005 hat Hypothese 1 (SSR-Backend-URL) gehärtet, traf aber den eigentlichen Bug nicht — der ist Reverse-Proxy-Routing-Konflikt, gelöst in M11-HOTFIX-006.
+
+---
+
+### M11-HOTFIX-009 — Application-Lifecycle Auto-Stop bei Event-Ende (Issue #23 Befund 2, ADR-057)
+
+**Status:** `[ERLEDIGT]` 2026-05-03 — Owner-Freigabe von Patrick im RC-3-Triage-Block (Variante A); ADR-057 `Accepted`. Branch `claude/m11-hotfix-009-app-lifecycle-autostop` gestackt auf PR [#29](https://github.com/Paddel87/HC-Map/pull/29).
+
+**Problem:** Issue [#23](https://github.com/Paddel87/HC-Map/issues/23) Befund 2 (Operator-Feldtest, RC-3-Phase Nodica1) — drei zusammengehörige Beobachtungen:
+- 2a: Live-Event wird beendet, Applications bleiben offen-laufend → Lifecycle-Inkonsistenz.
+- 2b: Im laufenden Live-Event hat eine einzelne Application keinen sichtbaren Stop-Button — Workaround über „Event bearbeiten" mit manueller Eingabe.
+- 2c: Backend-Validatoren („Application endet nach Event-Ende") greifen korrekt, aber UX ist Sackgasse — User läuft erst beim Submit in den Konflikt.
+
+**Deliverables (alle erledigt):**
+- **ADR-057** (`Accepted`) in [`docs/decisions.md`](./decisions.md): Variante A (Backend Auto-Stop + Stop-Button + Pre-Submit-Hint), B/C verworfen, vier Out-of-Scope-Punkte (Auto-Restart, Multi-Active im Live-Modus, Audit-Log, Migrations-Daten-Reparatur).
+- **Backend-Helper** [`backend/app/services/events.py:auto_stop_open_applications`](../backend/app/services/events.py): UPDATE-by-event_id-Query, idempotent, Trigger setzt `updated_at` (RxDB-Cursor advanciert).
+- **Backend-Pfad 1 (POST `/api/events/{id}/end`):** [`end_event`](../backend/app/services/events.py) ruft Helper nach `flush()`. Direkter Trigger.
+- **Backend-Pfad 2 (PATCH `/api/events/{id}`):** [`update_event`](../backend/app/services/events.py) merkt sich `was_open = ended_at is None` vor dem Update, ruft Helper wenn `ended_at` von null auf non-null wechselt.
+- **Backend-Pfad 3 (RxDB-Push):** [`push_events`](../backend/app/sync/services.py) macht denselben `was_open`-Check innerhalb der `begin_nested()`-Savepoint-Transaktion. Lazy-Import von `auto_stop_open_applications` zur Vermeidung zirkulärer Module-Imports.
+- **Frontend-Stop-Button** in [`event-detail-view.tsx:ApplicationsTimeline`](../frontend/src/components/event/event-detail-view.tsx): pro aktive Application (`isLive && isActive`) ein `[data-testid="applications-timeline-stop"]`-Button mit `Square`-Icon, Klick ruft existierenden `handleEndApplication`-Handler. Komponente um Props `isLive` + `onStop` erweitert.
+- **Frontend Live-Validation** in [`event-edit-form.tsx`](../frontend/src/components/event/event-edit-form.tsx): `validateBackfill` läuft via `useMemo` auf jeden Form-State-Change. Errors werden auf `bounds`/`duration`/`overlap` gefiltert, bis der User submit drückt — ab dann sind alle Errors sichtbar (verhindert Noise auf First-Paint). Submit-Pfad nutzt dieselben `liveErrors` als Block-Bedingung statt Re-Validation.
+
+**Verifikation:**
+- Zwei neue pytest-Tests in [`backend/tests/test_events_live_api.py`](../backend/tests/test_events_live_api.py):
+  - `test_end_event_auto_stops_running_applications`: Event → 2 Applications, eine manuell beendet vor Event-Ende, andere läuft → Event-Ende, beide haben `ended_at`, Auto-gestoppte hat exakt `event.ended_at`-Timestamp.
+  - `test_patch_event_with_ended_at_auto_stops_applications`: PATCH-Pfad-Variante.
+- `uv run pytest -q` → **258/258 grün** (256 + 2 neue).
+- `uv run ruff check app tests` → All checks passed.
+- `uv run ruff format` (auto-applied auf services.py + test): clean nach Re-Format.
+- `pnpm typecheck` → clean.
+- `pnpm lint` → clean.
+- `pnpm test` → **282/282 grün**.
+- `pnpm prettier --check` (per-file) → clean.
+- **Browser-Verifikation** (Dev-Stack lokal hochgefahren via `preview_*`, Alembic-Migration aus M11-HOTFIX-008 angewandt):
+  - End-to-End API-Smoke: Event-Start mit Title → 2 Applications gestartet → Event beendet → beide Applications haben `ended_at` exakt = `event.ended_at` (Auto-Stop greift).
+  - Frontend Stop-Button: Event-Detail-View zeigt `[data-testid="applications-timeline-stop"]`-Button für aktive Application; Klick → Status wechselt von „läuft" zu „beendet", Button verschwindet (kein zweiter Stop möglich).
+
+**Bezug:**
+- Issue: [#23 — Operator-Befundbericht I Befund 2](https://github.com/Paddel87/HC-Map/issues/23) (Application-Lifecycle).
+- ADR: [ADR-057 — Application-Lifecycle Auto-Stop](./decisions.md) (Status `Accepted`).
+- Vorgänger: ADR-011 (Live-Modus Lifecycle), ADR-029 (FWW vs LWW), ADR-038 (Detail-View), ADR-039/040 (Backfill-/Edit-Validation).
+- Folge: Operator-Verifikation auf Nodica1 nach Stack-Merge (idealerweise live-Event mit zwei parallelen Applications anlegen, Event beenden, prüfen dass beide auf ended_at gesetzt sind).
 
 ---
 

--- a/frontend/src/app/(protected)/events/[id]/page.tsx
+++ b/frontend/src/app/(protected)/events/[id]/page.tsx
@@ -236,6 +236,7 @@ function synthesizeFromRxdb(doc: EventDocType, participantIds: string[]): EventD
     lat: doc.lat,
     lon: doc.lon,
     reveal_participants: doc.reveal_participants,
+    title: doc.title,
     note: doc.note,
     legacy_external_ref: doc.legacy_external_ref,
     created_by: doc.created_by,

--- a/frontend/src/app/(protected)/page.tsx
+++ b/frontend/src/app/(protected)/page.tsx
@@ -15,6 +15,7 @@ interface EventListItem {
   ended_at: string | null;
   lat: number | string;
   lon: number | string;
+  title: string | null;
   note: string | null;
 }
 
@@ -93,22 +94,28 @@ export default async function DashboardPage() {
           <CardContent className="text-sm">
             {events && events.items.length > 0 ? (
               <ul className="flex flex-col gap-2">
-                {events.items.map((event) => (
-                  <li key={event.id}>
-                    <Link
-                      href={`/events/${event.id}`}
-                      className="flex flex-col gap-0.5 rounded-md border border-slate-100 px-3 py-2 transition-colors hover:bg-slate-50 dark:border-slate-800 dark:hover:bg-slate-900"
-                    >
-                      <span className="font-medium">
-                        {new Date(event.started_at).toLocaleString("de-DE")}
-                      </span>
-                      <span className="text-xs text-slate-500 dark:text-slate-400">
-                        {coerceNumber(event.lat).toFixed(4)}, {coerceNumber(event.lon).toFixed(4)}
-                        {event.note ? ` — ${event.note}` : ""}
-                      </span>
-                    </Link>
-                  </li>
-                ))}
+                {events.items.map((event) => {
+                  const trimmedTitle = event.title?.trim();
+                  return (
+                    <li key={event.id}>
+                      <Link
+                        href={`/events/${event.id}`}
+                        className="flex flex-col gap-0.5 rounded-md border border-slate-100 px-3 py-2 transition-colors hover:bg-slate-50 dark:border-slate-800 dark:hover:bg-slate-900"
+                      >
+                        <span className="font-medium">
+                          {trimmedTitle ?? new Date(event.started_at).toLocaleString("de-DE")}
+                        </span>
+                        <span className="text-xs text-slate-500 dark:text-slate-400">
+                          {trimmedTitle
+                            ? `${new Date(event.started_at).toLocaleString("de-DE")} · `
+                            : ""}
+                          {coerceNumber(event.lat).toFixed(4)}, {coerceNumber(event.lon).toFixed(4)}
+                          {event.note ? ` — ${event.note}` : ""}
+                        </span>
+                      </Link>
+                    </li>
+                  );
+                })}
               </ul>
             ) : (
               <p className="text-slate-500 dark:text-slate-400">

--- a/frontend/src/components/event/event-backfill-form.tsx
+++ b/frontend/src/components/event/event-backfill-form.tsx
@@ -72,6 +72,7 @@ export function EventBackfillForm({ user }: EventBackfillFormProps) {
   const [coords, setCoords] = useState<{ lat: number; lon: number } | null>(null);
   const [eventStartedAt, setEventStartedAt] = useState("");
   const [eventEndedAt, setEventEndedAt] = useState("");
+  const [title, setTitle] = useState("");
   const [note, setNote] = useState("");
   const [applications, setApplications] = useState<ApplicationRow[]>([]);
   const [errors, setErrors] = useState<BackfillError[]>([]);
@@ -158,6 +159,7 @@ export function EventBackfillForm({ user }: EventBackfillFormProps) {
         lon: coords!.lon,
         legacy_external_ref: null,
         reveal_participants: false,
+        title: title.trim() || null,
         note: note.trim() || null,
         created_by: user.id,
         created_at: now,
@@ -304,6 +306,26 @@ export function EventBackfillForm({ user }: EventBackfillFormProps) {
               </p>
             ) : null}
           </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Titel (optional)</CardTitle>
+          <CardDescription>
+            Kurze Bezeichnung zur Wiederfindung im Dashboard und auf der Karte. Maximal 120 Zeichen.
+            Leer lassen = Anzeige fällt auf Startzeit + Koordinaten zurück.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="z. B. „Konzert in Bremen"
+            maxLength={120}
+            data-testid="event-backfill-title"
+          />
         </CardContent>
       </Card>
 

--- a/frontend/src/components/event/event-create-form.tsx
+++ b/frontend/src/components/event/event-create-form.tsx
@@ -36,6 +36,7 @@ export function EventCreateForm({ user }: EventCreateFormProps) {
   const geolocation = useGeolocation({ auto: true });
   const [coords, setCoords] = useState<{ lat: number; lon: number } | null>(null);
   const [recipient, setRecipient] = useState<PersonRead | null>(null);
+  const [title, setTitle] = useState("");
   const [note, setNote] = useState("");
   const [pending, setPending] = useState(false);
 
@@ -72,6 +73,7 @@ export function EventCreateForm({ user }: EventCreateFormProps) {
         lon: coords.lon,
         legacy_external_ref: null,
         reveal_participants: false,
+        title: title.trim() || null,
         note: note.trim() || null,
         // Server overrides created_by with the authenticated user (ADR-029).
         created_by: user.id,
@@ -177,6 +179,26 @@ export function EventCreateForm({ user }: EventCreateFormProps) {
             value={recipient}
             onChange={setRecipient}
             excludePersonIds={[user.person_id]}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Titel (optional)</CardTitle>
+          <CardDescription>
+            Kurze Bezeichnung zur Wiederfindung im Dashboard und auf der Karte. Maximal 120 Zeichen.
+            Leer lassen = Anzeige fällt auf Startzeit + Koordinaten zurück.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <input
+            type="text"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="z. B. „Konzert in Bremen"
+            maxLength={120}
+            className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 dark:border-slate-800 dark:bg-slate-950 dark:focus-visible:ring-slate-300"
           />
         </CardContent>
       </Card>

--- a/frontend/src/components/event/event-detail-view.tsx
+++ b/frontend/src/components/event/event-detail-view.tsx
@@ -16,7 +16,7 @@
  *      defense-in-depth step described in ADR-036 §B.
  */
 
-import { Flag, Pause, Pencil, Play, Plus } from "lucide-react";
+import { Flag, Pause, Pencil, Play, Plus, Square } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
@@ -188,7 +188,12 @@ export function EventDetailView({ user, initialEvent }: EventDetailViewProps) {
                 : "In diesem Event wurden keine Applications erfasst."}
             </p>
           ) : (
-            <ApplicationsTimeline applications={applications} now={now} />
+            <ApplicationsTimeline
+              applications={applications}
+              now={now}
+              isLive={isLive}
+              onStop={isLive ? handleEndApplication : undefined}
+            />
           )}
         </CardContent>
       </Card>
@@ -292,9 +297,13 @@ function useApplications(eventId: string): ApplicationDocType[] {
 function ApplicationsTimeline({
   applications,
   now,
+  isLive,
+  onStop,
 }: {
   applications: ApplicationDocType[];
   now: number;
+  isLive: boolean;
+  onStop?: (applicationId: string) => Promise<void> | void;
 }) {
   // M7.5: resolve restraint_type_ids → display names via the M7.x
   // catalog cache. Same query key the picker uses, so this view shares
@@ -402,7 +411,21 @@ function ApplicationsTimeline({
                 </p>
               ) : null}
             </div>
-            <span className="font-mono text-base tabular-nums">{formatDuration(seconds)}</span>
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-base tabular-nums">{formatDuration(seconds)}</span>
+              {isLive && isActive && onStop ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => void onStop(application.id)}
+                  data-testid="applications-timeline-stop"
+                  aria-label={`Application #${application.sequence_no} beenden`}
+                >
+                  <Square aria-hidden /> Stop
+                </Button>
+              ) : null}
+            </div>
           </li>
         );
       })}

--- a/frontend/src/components/event/event-detail-view.tsx
+++ b/frontend/src/components/event/event-detail-view.tsx
@@ -112,6 +112,14 @@ export function EventDetailView({ user, initialEvent }: EventDetailViewProps) {
     <div className="flex flex-col gap-4" data-testid="event-detail-view">
       <Card>
         <CardHeader>
+          {event.title?.trim() ? (
+            <p
+              className="text-lg font-semibold leading-tight text-slate-900 dark:text-slate-100"
+              data-testid="event-detail-title"
+            >
+              {event.title.trim()}
+            </p>
+          ) : null}
           <CardTitle className="flex items-center justify-between gap-2 text-base">
             <span>{isLive ? "Event läuft" : "Event beendet"}</span>
             <span className="font-mono text-2xl tabular-nums">{formatDuration(totalSeconds)}</span>
@@ -222,6 +230,7 @@ interface MergedEvent {
   ended_at: string | null;
   lat: number | string;
   lon: number | string;
+  title: string | null;
   note: string | null;
   plus_code: string;
   participants: readonly PersonRead[];
@@ -236,6 +245,7 @@ function mergeEvent(server: EventDetail, doc: EventDocType | null): MergedEvent 
     ended_at: doc.ended_at,
     lat: doc.lat,
     lon: doc.lon,
+    title: doc.title,
     note: doc.note,
     plus_code: server.plus_code,
     participants: server.participants,

--- a/frontend/src/components/event/event-edit-form.tsx
+++ b/frontend/src/components/event/event-edit-form.tsx
@@ -100,7 +100,31 @@ export function EventEditForm({ user, initialEvent }: EventEditFormProps) {
   const [applications, setApplications] = useState<EditableApplication[]>([]);
   const [loading, setLoading] = useState(true);
   const [pending, setPending] = useState(false);
-  const [errors, setErrors] = useState<BackfillError[]>([]);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+
+  // ADR-057 §E: re-run validateBackfill on every form-state change so
+  // bounds/duration violations surface inline instead of waiting for
+  // the user to hit submit. Errors are only rendered after the first
+  // submit attempt to avoid noisy first-paint complaints about empty
+  // fields the user hasn't touched yet.
+  const liveErrors = useMemo<BackfillError[]>(() => {
+    if (!event) return [];
+    const result = validateBackfill({
+      lat: typeof initialEvent.lat === "number" ? initialEvent.lat : Number(initialEvent.lat),
+      lon: typeof initialEvent.lon === "number" ? initialEvent.lon : Number(initialEvent.lon),
+      startedAt: initialEvent.started_at,
+      endedAt: localToIso(event.endedAt),
+      applications: applications.map((a) => ({
+        uiId: a.id,
+        startedAt: localToIso(a.startedAt),
+        endedAt: localToIso(a.endedAt),
+        recipientId: a.recipientId || null,
+        note: a.note || null,
+      })),
+    });
+    return result.valid ? [] : result.errors;
+  }, [event, applications, initialEvent]);
+  const errors = submitAttempted ? liveErrors : liveErrors.filter(isBoundsOrDuration);
 
   // Load event + applications from RxDB once (ADR-040 §F).
   useEffect(() => {
@@ -200,31 +224,15 @@ export function EventEditForm({ user, initialEvent }: EventEditFormProps) {
 
   async function handleSubmit(formEvent: React.FormEvent<HTMLFormElement>) {
     formEvent.preventDefault();
+    setSubmitAttempted(true);
     if (!database || !event || !eventInitial) return;
 
-    // Validate via the M5c.3 helper — started_at values are immutable
-    // here, so we hand them through unchanged (ADR-040 §G).
-    const validation = validateBackfill({
-      lat: typeof initialEvent.lat === "number" ? initialEvent.lat : Number(initialEvent.lat),
-      lon: typeof initialEvent.lon === "number" ? initialEvent.lon : Number(initialEvent.lon),
-      startedAt: initialEvent.started_at,
-      endedAt: localToIso(event.endedAt),
-      applications: applications.map((a) => ({
-        uiId: a.id,
-        startedAt: localToIso(a.startedAt),
-        endedAt: localToIso(a.endedAt),
-        recipientId: a.recipientId || null,
-        note: a.note || null,
-      })),
-    });
-    if (!validation.valid) {
-      setErrors(validation.errors);
-      toast.error(`${validation.errors.length} Eingabe-Probleme`, {
+    if (liveErrors.length > 0) {
+      toast.error(`${liveErrors.length} Eingabe-Probleme`, {
         description: "Bitte die markierten Felder prüfen.",
       });
       return;
     }
-    setErrors([]);
 
     setPending(true);
     try {
@@ -584,4 +592,9 @@ function setEquals(a: readonly string[], b: readonly string[]): boolean {
     if (!set.has(item)) return false;
   }
   return true;
+}
+
+function isBoundsOrDuration(err: BackfillError): boolean {
+  if (err.kind === "event") return err.field === "duration";
+  return err.field === "bounds" || err.field === "duration" || err.field === "overlap";
 }

--- a/frontend/src/components/event/event-edit-form.tsx
+++ b/frontend/src/components/event/event-edit-form.tsx
@@ -50,6 +50,7 @@ const PLATFORM_CONFIRM_LOCK = (message: string): boolean =>
 
 interface EditableEvent {
   endedAt: string; // datetime-local; "" if currently null
+  title: string;
   note: string;
   revealParticipants: boolean;
 }
@@ -116,6 +117,7 @@ export function EventEditForm({ user, initialEvent }: EventEditFormProps) {
       if (cancelled) return;
       const eventEditable: EditableEvent = {
         endedAt: isoToLocal(eventDoc?.ended_at ?? initialEvent.ended_at),
+        title: eventDoc?.title ?? initialEvent.title ?? "",
         note: eventDoc?.note ?? initialEvent.note ?? "",
         revealParticipants: eventDoc?.reveal_participants ?? initialEvent.reveal_participants,
       };
@@ -229,6 +231,9 @@ export function EventEditForm({ user, initialEvent }: EventEditFormProps) {
       const eventDoc = await database.events.findOne(initialEvent.id).exec();
       if (eventDoc) {
         const patch: Partial<EventDocType> = {};
+        if (event.title !== eventInitial.title) {
+          patch.title = event.title.trim() || null;
+        }
         if (event.note !== eventInitial.note) {
           patch.note = event.note.trim() || null;
         }
@@ -340,6 +345,18 @@ export function EventEditForm({ user, initialEvent }: EventEditFormProps) {
                 {fieldErrorMessage(eventErrors, "duration")}
               </p>
             ) : null}
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="event-edit-title">Titel (optional, max. 120 Zeichen)</Label>
+            <Input
+              id="event-edit-title"
+              type="text"
+              value={event.title}
+              onChange={(e) => patchEvent({ title: e.target.value })}
+              maxLength={120}
+              placeholder="z. B. „Konzert in Bremen"
+              data-testid="event-edit-title"
+            />
           </div>
           <div className="flex flex-col gap-1">
             <Label htmlFor="event-edit-note">Notiz</Label>

--- a/frontend/src/components/map/map-view.tsx
+++ b/frontend/src/components/map/map-view.tsx
@@ -374,9 +374,17 @@ function FilterToggleButton({ active, onClick }: { active: boolean; onClick: () 
 
 function EventPopupContent({ event }: { event: MappableEvent }) {
   const isLive = event.ended_at === null;
+  const trimmedTitle = event.title?.trim();
   return (
     <div className="flex flex-col gap-1 text-sm" data-testid="map-event-popup">
-      <div className="font-medium">{formatDate(event.started_at)}</div>
+      {trimmedTitle ? (
+        <div className="font-medium" data-testid="map-event-popup-title">
+          {trimmedTitle}
+        </div>
+      ) : null}
+      <div className={trimmedTitle ? "text-xs text-slate-600" : "font-medium"}>
+        {formatDate(event.started_at)}
+      </div>
       <div className="text-xs text-slate-600">
         {event.lat.toFixed(5)}, {event.lon.toFixed(5)}
       </div>

--- a/frontend/src/lib/map/event-marker-data.ts
+++ b/frontend/src/lib/map/event-marker-data.ts
@@ -14,6 +14,7 @@ export interface MappableEvent {
   lon: number;
   started_at: string;
   ended_at: string | null;
+  title: string | null;
   note: string | null;
   reveal_participants: boolean;
 }
@@ -62,6 +63,7 @@ export function selectMappableEvents(docs: readonly EventDocType[]): MappableEve
       lon: doc.lon,
       started_at: doc.started_at,
       ended_at: doc.ended_at,
+      title: doc.title,
       note: doc.note,
       reveal_participants: doc.reveal_participants,
     });

--- a/frontend/src/lib/rxdb/database.ts
+++ b/frontend/src/lib/rxdb/database.ts
@@ -79,11 +79,15 @@ async function buildDatabase(): Promise<HCMapDatabase> {
       // Schema v0 → v1 (ADR-050): rename `w3w_legacy` to
       // `legacy_external_ref`. Old field is dropped, new field carries
       // the same value (or null for docs that never had one).
+      // Schema v1 → v2 (ADR-056, M11-HOTFIX-008): add optional `title`
+      // (default null — UI falls back to start-time/coordinate display
+      // when unset).
       migrationStrategies: {
         1: (doc: Record<string, unknown>) => {
           const { w3w_legacy, ...rest } = doc;
           return { ...rest, legacy_external_ref: w3w_legacy ?? null };
         },
+        2: (doc: Record<string, unknown>) => ({ ...doc, title: null }),
       },
     },
     applications: {

--- a/frontend/src/lib/rxdb/schemas/event.schema.json
+++ b/frontend/src/lib/rxdb/schemas/event.schema.json
@@ -1,7 +1,7 @@
 {
   "title": "Event",
   "description": "Event document replicated via /api/sync/events. Wire-format contract shared with backend Pydantic EventDoc (ADR-031).",
-  "version": 1,
+  "version": 2,
   "primaryKey": "id",
   "type": "object",
   "properties": {
@@ -34,6 +34,10 @@
     },
     "reveal_participants": {
       "type": "boolean"
+    },
+    "title": {
+      "type": ["string", "null"],
+      "maxLength": 120
     },
     "note": {
       "type": ["string", "null"]

--- a/frontend/src/lib/rxdb/types.ts
+++ b/frontend/src/lib/rxdb/types.ts
@@ -22,6 +22,7 @@ export interface EventDocType {
   lon: number;
   legacy_external_ref: string | null;
   reveal_participants: boolean;
+  title: string | null;
   note: string | null;
   created_by: string | null;
   created_at: string;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -17,6 +17,7 @@ export interface EventListItem {
   lat: number | string;
   lon: number | string;
   reveal_participants: boolean;
+  title: string | null;
   note: string | null;
   legacy_external_ref: string | null;
   created_by: string | null;
@@ -58,6 +59,7 @@ export interface EventStartPayload {
   lon: number;
   recipient_id?: string;
   reveal_participants?: boolean;
+  title?: string;
   note?: string;
 }
 


### PR DESCRIPTION
## Summary

- **Backend:** Wenn `event.ended_at` von null auf non-null wechselt, werden alle laufenden Applications dieses Events transaktional auf den Event-Ende-Zeitstempel gesetzt. Greift an drei Pfaden — `POST /api/events/{id}/end`, `PATCH /api/events/{id}`, RxDB-Event-Push.
- **Frontend Stop-Button:** Pro aktive Application in der Event-Detail-Timeline ein Stop-Button (`Square`-Icon) — kein Umweg mehr über „Event bearbeiten".
- **Frontend Live-Validation:** `event-edit-form.tsx` validiert via `useMemo` bei jeder Änderung; bounds/duration/overlap-Errors sind sofort sichtbar (vor dem ersten Submit-Klick werden andere Error-Typen unterdrückt → kein Noise).
- **ADR-057** (`Accepted`) dokumentiert Entscheidung (Variante A vs. B/C verworfen, vier Out-of-Scope-Punkte).

Closes [#23](https://github.com/Paddel87/HC-Map/issues/23) Befund 2 (alle drei Sub-Befunde 2a/2b/2c).

## Stack-Hinweis

PR-Base ist [`claude/m11-hotfix-008-event-title`](https://github.com/Paddel87/HC-Map/pull/29), nicht `main`. Sobald [#28](https://github.com/Paddel87/HC-Map/pull/28) und [#29](https://github.com/Paddel87/HC-Map/pull/29) gemerged sind, wechselt die Base automatisch auf `main`.

## Verifikation

- 2 neue pytest-Tests (`test_end_event_auto_stops_running_applications`, `test_patch_event_with_ended_at_auto_stops_applications`) decken End- und Patch-Pfad ab.
- Backend `pytest` → **258/258 grün** (256 + 2 neue), `ruff check` + `ruff format --check` clean.
- Frontend `vitest` → **282/282 grün**, `typecheck`/`lint`/`prettier --check` clean.
- End-to-End-Browser-Smoke (Dev-Stack lokal):
  - Event mit Title → 2 Applications gestartet (eine manuell beendet, eine läuft) → Event-Ende → beide haben `ended_at = event.ended_at` (Auto-Stop für die laufende, FWW-Erhalt der manuellen).
  - Detail-View Stop-Button: Klick → Application-Status „läuft" → „beendet", Button verschwindet (kein zweiter Stop möglich).

## Test plan

- [x] Backend pytest 258/258 (incl. 2 neue Auto-Stop-Tests)
- [x] Frontend vitest 282/282
- [x] Browser-Smoke: API-Auto-Stop end-to-end + Frontend-Stop-Button
- [ ] Operator-Verifikation auf Nodica1 nach Stack-Merge: Live-Event mit zwei parallelen Applications anlegen, Event beenden, beide Applications haben Event-Ende-Timestamp
- [ ] Operator-Verifikation: Stop-Button pro Application im Live-Modus funktioniert isoliert
- [ ] Operator-Verifikation: Edit-Form zeigt sofortigen Hint, wenn Application-Ende außerhalb Event-Fenster getippt wird

🤖 Generated with [Claude Code](https://claude.com/claude-code)