### PR TITLE
fix(m11-hotfix-009): application-lifecycle Auto-Stop bei Event-Ende (Issue #23, ADR-057)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Bis zum ersten Go-Live (M11) bleibt das Projekt auf `0.0.0`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **M11-HOTFIX-009 — Application-Lifecycle Auto-Stop bei Event-Ende (2026-05-03, Issue [#23](https://github.com/Paddel87/HC-Map/issues/23) Befund 2, ADR-057).**
+  Wenn ein Event beendet wird, werden alle noch laufenden Applications dieses Events automatisch auf den Event-Ende-Zeitstempel gesetzt — Lifecycle-Kaskade ist jetzt konzeptkonform. Greift an drei Server-Pfaden: `POST /api/events/{id}/end` (Live-Modus), `PATCH /api/events/{id}` (Edit-Form) und RxDB-Event-Push (Offline-Reconnect-Fall). Frontend ergänzt um Stop-Button pro aktive Application in der Timeline (kein Umweg mehr über „Event bearbeiten") und um Live-Validation im Edit-Form (Bounds-Verletzungen sind sofort sichtbar, nicht erst nach Submit-Klick). Volle Backend-Suite **258/258** + Frontend-Suite **282/282** grün, End-to-End-Browser-Smoke bestätigt: Event mit zwei laufenden Applications → Event-Ende → beide Applications haben exakt `event.ended_at`-Timestamp.
+
 ### Added
 
 - **M11-HOTFIX-008 — Optionales `event.title`-Feld für Identifikation und Wiederfindung (2026-05-03, Issue [#27](https://github.com/Paddel87/HC-Map/issues/27) Befund 4+5, ADR-056).**

--- a/backend/app/services/events.py
+++ b/backend/app/services/events.py
@@ -172,7 +172,9 @@ async def auto_stop_open_applications(
         )
         .values(ended_at=ended_at)
     )
-    return int(result.rowcount or 0)
+    # `result` is a CursorResult for bulk DML, which carries rowcount;
+    # the typed Result[Any] return signature hides that, hence the cast.
+    return int(getattr(result, "rowcount", 0) or 0)
 
 
 async def list_participants(session: AsyncSession, event_id: uuid.UUID) -> Sequence[Person]:

--- a/backend/app/services/events.py
+++ b/backend/app/services/events.py
@@ -6,9 +6,10 @@ import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.application import Application
 from app.models.event import Event, EventParticipant
 from app.models.person import Person
 from app.schemas.event import EventCreate, EventStart, EventUpdate
@@ -83,9 +84,14 @@ async def update_event(
     event: Event,
     payload: EventUpdate,
 ) -> Event:
+    was_open = event.ended_at is None
     for field, value in payload.model_dump(exclude_unset=True).items():
         setattr(event, field, value)
     await session.flush()
+    # ADR-057: when ended_at transitions from null to non-null, cascade
+    # to any still-running applications.
+    if was_open and event.ended_at is not None:
+        await auto_stop_open_applications(session, event.id, event.ended_at)
     await session.refresh(event)
     return event
 
@@ -129,12 +135,44 @@ async def start_event(
 
 
 async def end_event(session: AsyncSession, event: Event) -> Event:
-    """Set ``ended_at = now()`` if not already set (idempotent)."""
+    """Set ``ended_at = now()`` if not already set (idempotent).
+
+    Also auto-stops every still-running Application of the event by
+    setting their ``ended_at`` to the same timestamp (ADR-057). This
+    keeps the lifecycle cascade consistent — a finished event must
+    not have running children.
+    """
     if event.ended_at is None:
-        event.ended_at = datetime.now(tz=UTC)
+        ended_at = datetime.now(tz=UTC)
+        event.ended_at = ended_at
         await session.flush()
+        await auto_stop_open_applications(session, event.id, ended_at)
         await session.refresh(event)
     return event
+
+
+async def auto_stop_open_applications(
+    session: AsyncSession,
+    event_id: uuid.UUID,
+    ended_at: datetime,
+) -> int:
+    """Close every running, non-deleted Application of the event (ADR-057).
+
+    Returns the number of Application rows that were updated. Idempotent:
+    if no Applications are running, the UPDATE matches zero rows and
+    nothing is changed. ``updated_at`` is left to the database trigger
+    (``set_updated_at``, see M1 migration) so the RxDB cursor advances.
+    """
+    result = await session.execute(
+        update(Application)
+        .where(
+            Application.event_id == event_id,
+            Application.ended_at.is_(None),
+            Application.is_deleted.is_(False),
+        )
+        .values(ended_at=ended_at)
+    )
+    return int(result.rowcount or 0)
 
 
 async def list_participants(session: AsyncSession, event_id: uuid.UUID) -> Sequence[Person]:

--- a/backend/app/sync/services.py
+++ b/backend/app/sync/services.py
@@ -207,10 +207,17 @@ async def push_events(
         if conflict is not None:
             conflicts.append(conflict)
             continue
+        was_open = existing.ended_at is None
         _apply_event_update(existing, new_doc)
         try:
             async with session.begin_nested():
                 await session.flush()
+                # ADR-057: cascade auto-stop to running applications when
+                # the event transitions from open to ended.
+                if was_open and existing.ended_at is not None:
+                    from app.services.events import auto_stop_open_applications
+
+                    await auto_stop_open_applications(session, existing.id, existing.ended_at)
         except (IntegrityError, ProgrammingError):
             # Savepoint already rolled back; outer TX still alive. The local
             # ORM state is dirty but we abandon this item.

--- a/backend/tests/test_events_live_api.py
+++ b/backend/tests/test_events_live_api.py
@@ -124,3 +124,57 @@ async def test_end_event_unknown_id_returns_404(
         "/api/events/00000000-0000-0000-0000-000000000000/end",
     )
     assert resp.status_code == 404
+
+
+async def test_end_event_auto_stops_running_applications(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """ADR-057: ending an event must cascade to running applications."""
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    start = await post_with_csrf(client, csrf, "/api/events/start", json={"lat": "0", "lon": "0"})
+    event_id = start.json()["id"]
+    # Two applications: one will be ended manually before the event ends,
+    # the other stays running and must be auto-stopped.
+    app1 = await post_with_csrf(client, csrf, f"/api/events/{event_id}/applications/start", json={})
+    app1_id = app1.json()["id"]
+    await post_with_csrf(client, csrf, f"/api/applications/{app1_id}/end")
+    app2 = await post_with_csrf(client, csrf, f"/api/events/{event_id}/applications/start", json={})
+    app2_id = app2.json()["id"]
+
+    end = await post_with_csrf(client, csrf, f"/api/events/{event_id}/end")
+    assert end.status_code == 200, end.text
+    event_ended_at = end.json()["ended_at"]
+    assert event_ended_at is not None
+
+    # Both applications must now be ended; app2 should match the event's
+    # ended_at timestamp (auto-stop), app1 keeps its earlier ended_at.
+    app1_after = await client.get(f"/api/applications/{app1_id}")
+    app2_after = await client.get(f"/api/applications/{app2_id}")
+    assert app1_after.json()["ended_at"] is not None
+    assert app2_after.json()["ended_at"] == event_ended_at
+
+
+async def test_patch_event_with_ended_at_auto_stops_applications(
+    client: AsyncClient,
+    async_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """ADR-057: PATCH /api/events with ``ended_at`` must also cascade."""
+    _, csrf = await login_as(client, async_session_factory, role=UserRole.ADMIN)
+    start = await post_with_csrf(client, csrf, "/api/events/start", json={"lat": "0", "lon": "0"})
+    event_id = start.json()["id"]
+    app = await post_with_csrf(client, csrf, f"/api/events/{event_id}/applications/start", json={})
+    app_id = app.json()["id"]
+
+    patch_payload = {"ended_at": datetime.now(tz=UTC).isoformat()}
+    patch = await client.patch(
+        f"/api/events/{event_id}",
+        json=patch_payload,
+        headers={"X-CSRF-Token": csrf},
+    )
+    assert patch.status_code == 200, patch.text
+    event_ended_at = patch.json()["ended_at"]
+    assert event_ended_at is not None
+
+    app_after = await client.get(f"/api/applications/{app_id}")
+    assert app_after.json()["ended_at"] is not None

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5173,4 +5173,85 @@ Bestehende lokale RxDB-Docs in IndexedDB werden bei nächstem Mount automatisch 
 
 ---
 
+## ADR-057 — Application-Lifecycle: Auto-Stop bei Event-Ende + Stop-Button pro Application (Issue #23 Befund 2)
+
+**Status:** Accepted
+**Datum:** 2026-05-03
+**Freigabe:** 2026-05-03 (Patrick — Variante A, Reihenfolge-Freigabe nach Operator-Befundbericht-Triage)
+**Kategorie:** §4.5 API-Vertrags-Änderung (zusätzliche Server-Side-Effekte beim Event-Ende: Auto-Cascade auf laufende Applications). Sekundär §4.4 (Service-Layer-Logik im Sync-Pfad).
+**Vorgänger:** [ADR-011](./decisions.md) (Live-Modus Lifecycle), [ADR-029](./decisions.md) (RxDB-Replication / FWW vs LWW), [ADR-038](./decisions.md) (Event-Detail-View), [ADR-039](./decisions.md) (Backfill-Validation), [ADR-040](./decisions.md) (Edit-UI).
+
+### Kontext
+
+Issue [#23](https://github.com/Paddel87/HC-Map/issues/23) Befund 2 (Operator-Feldtest, RC-3-Phase Nodica1) — drei zusammengehörige Beobachtungen:
+
+- **2a:** Ein Live-Event wird beendet, aber zugehörige Applications bleiben offen-laufend. Der Container-Event ist terminiert, die Children sind es nicht — inkonsistent gegenüber der erwartbaren Lifecycle-Kaskade.
+- **2b:** Im laufenden Live-Event hat eine einzelne Application keinen sichtbaren Stop-Button. Der einzige Weg zum Beenden geht über „Event bearbeiten" + manuelle Ende-Datum-Eingabe — fehleranfällig (siehe 2c).
+- **2c:** Backend-Validatoren („Application endet nach dem Event-Ende", „Application-Ende liegt vor dem Start") greifen korrekt, sind aber UX-Sackgassen. Wenn das Frontend dieselbe Logik kennt, sollte es sie verwenden, statt den User in eine Backend-Validator-Kollision laufen zu lassen.
+
+### Entscheidungen
+
+**A. Backend Auto-Stop (Variante A aus dem Triage-Block).**
+
+Drei Alternativen wurden Patrick vorgelegt:
+- **A — Backend-Auto-Stop + Stop-Button + Frontend-Pre-Submit-Hint.** Beim Event-Ende setzt der Service alle nicht-beendeten Applications dieses Events transaktional auf `ended_at = event.ended_at`.
+- **B — Frontend-only Auto-Stop.** Beim Event-Beenden iteriert das Frontend über offene Applications und schickt einzelne PATCH-Requests. Verworfen: Race-Conditions bei Offline/Reconnect, mehrere Requests statt einer Transaktion.
+- **C — Nur Stop-Button + Pre-Submit-Hint, kein Auto-Stop.** Verworfen: Befund 2a (Konzeptbruch durch Lifecycle-Inkonsistenz) bleibt bestehen.
+
+**Patrick wählt A.** Begründung: Auto-Stop ist die einzige Variante, die die Lifecycle-Kaskade konzeptkonform macht — ohne sie bleibt der Datenstand inkonsistent (beendetes Event mit laufenden Applications). Backend-Touch ist klein.
+
+**B. Server-Side Auto-Stop an drei Code-Pfaden.**
+
+Auto-Stop muss überall greifen, wo `event.ended_at` von `null` auf `not null` wechselt:
+
+1. **`POST /api/events/{id}/end`** ([`backend/app/services/events.py:end_event`](../backend/app/services/events.py)) — Live-Modus-Beenden. Direkter Trigger.
+2. **`PATCH /api/events/{id}`** ([`backend/app/services/events.py:update_event`](../backend/app/services/events.py)) — Edit-Form setzt `ended_at` nachträglich (FWW-only-when-null, ADR-040 §C).
+3. **RxDB-Push** ([`backend/app/sync/services.py:_apply_event_update`](../backend/app/sync/services.py)) — Frontend-RxDB pusht ein Event mit `ended_at != null`.
+
+Alle drei Pfade rufen einen neuen Helper `auto_stop_open_applications(session, event_id, ended_at)` auf, der per UPDATE alle Application-Rows im Event mit `ended_at IS NULL AND is_deleted=false` auf den übergebenen Zeitstempel setzt. Transaktional Teil derselben Session — entweder beide Writes (Event + Children) oder keiner.
+
+**C. Idempotenz und FWW-Kompatibilität.**
+
+- **Idempotenz:** Wenn das Event bereits `ended_at` hat, ändert sich nichts. Der Helper läuft trotzdem, hat aber leere Working-Set (keine offenen Applications mehr).
+- **FWW-Kompatibilität:** Application's `ended_at` ist bisher LWW-frei (kein FWW-Constraint im Sync-Service). Der Auto-Stop überschreibt also keinen vom User gewollten späteren `ended_at`-Wert — wenn der Operator eine Application explizit später beenden wollte, muss er sie *vor* dem Event-Ende beenden.
+
+**D. Frontend: Stop-Button pro laufende Application.**
+
+In [`frontend/src/components/event/event-detail-view.tsx:ApplicationsTimeline`](../frontend/src/components/event/event-detail-view.tsx) bekommt jede aktive Application (`ended_at === null`) einen Stop-Button neben der Timer-Anzeige. Klick ruft denselben Handler wie der bestehende „Aktuelle beenden"-Button im Header (`handleEndApplication(id)`).
+
+Sichtbarkeit: nur wenn `isLive === true` (sonst gibt es keine aktiven Applications) und `endedAt === null`. `data-testid="applications-timeline-stop"` für Tests.
+
+**E. Frontend: Pre-Submit-Hint im Edit-Form.**
+
+Der bestehende [`validateBackfill`](../frontend/src/lib/event-backfill-validation.ts)-Helper liefert bereits `bounds`-Errors für „Application endet nach dem Event-Ende". Im [`event-edit-form.tsx`](../frontend/src/components/event/event-edit-form.tsx) wird die Validierung **bereits beim Tippen** (statt erst beim Submit) ausgewertet, wenn der User ein `ended_at`-Feld editiert. Der Hint erscheint inline am betroffenen Feld, der Submit-Pfad nutzt denselben Validator. Damit muss der Operator nicht erst submit klicken, um die Backend-Validator-Meldung zu sehen — der Konflikt wird sichtbar, sobald der Wert getippt ist.
+
+Implementiert über `useMemo` auf den aktuellen Form-State, der validateBackfill mit den lokalen Werten aufruft und die Errors anzeigt. Submit nutzt dieselben `errors` als Block-Bedingung.
+
+**F. Out-of-Scope (nicht Teil dieses ADR).**
+
+- **Auto-Restart:** Wenn ein Admin ein Event aus dem Soft-Delete restored (ended_at bleibt erhalten), werden Applications nicht „auto-resumed". Restore ist bereits Admin-only, manuelle Korrektur erlaubt.
+- **Auto-Stop im Live-Modus „Neue Application"-Trigger:** Wenn der Operator eine zweite Application startet während die erste läuft, beendet das die erste *nicht* automatisch. Multi-Active ist explizit erlaubt (parallele Restraints).
+- **Audit-Log für Auto-Stop:** Bisher kein dediziertes Audit (kein Audit-Log-System im Repo). Falls später eingeführt, würde Auto-Stop ein Audit-Event auslösen.
+- **Migrations-Daten-Reparatur:** Bestehende inkonsistente Rows (beendete Events mit laufenden Applications) werden *nicht* automatisch repariert. Der Operator kann Edit-Form nutzen.
+
+### Verworfene Alternativen
+
+- **Variante B (Frontend-only Auto-Stop).** Race-Conditions, mehrere Requests statt Transaktion, schwierig bei Offline/Reconnect-Replay.
+- **Variante C (nur Stop-Button + Hint, kein Auto-Stop).** Operator-Befund 2a (Lifecycle-Kaskade) bleibt unbehoben.
+- **Auto-Restart bei Event-Restore.** Operator-Erwartung wäre uneindeutig; manuelle Korrektur ist sicherer.
+
+### Folgearbeit
+
+- **M11-HOTFIX-009** (Fahrplan-Eintrag): Implementierung dieser ADR (Helper, drei Service-Pfade, Stop-Button, Edit-Form-Live-Validation, Tests).
+- **#23 Befund 2 schließen** nach Operator-Verifikation auf Production (Live-Event mit zwei Applications anlegen, Event beenden, beide Applications auf den Event-Ende-Zeitstempel gesetzt).
+
+### Referenzen
+
+- [Issue #23 — Operator-Befundbericht I Befund 2](https://github.com/Paddel87/HC-Map/issues/23)
+- [ADR-011 — Live-Modus Lifecycle](./decisions.md)
+- [ADR-029 — RxDB-Replication FWW vs LWW](./decisions.md)
+- Code-Stellen: [`backend/app/services/events.py`](../backend/app/services/events.py), [`backend/app/services/applications.py`](../backend/app/services/applications.py), [`backend/app/sync/services.py`](../backend/app/sync/services.py), [`frontend/src/components/event/event-detail-view.tsx`](../frontend/src/components/event/event-detail-view.tsx), [`frontend/src/components/event/event-edit-form.tsx`](../frontend/src/components/event/event-edit-form.tsx)
+
+---
+
 **Hinweis zur Initialisierungs-Entscheidung:** Die initiale Anpassung der Vorlagen-Dokumente an HC-Map-Komplexität ist in **ADR-009 (Vorgehensmodell: Vision-driven Scoping vor Code)** dokumentiert. Diese ADR übernimmt die Funktion, die in der generischen Vorlage für ADR-001 vorgesehen war.

--- a/docs/fahrplan.md
+++ b/docs/fahrplan.md
@@ -135,6 +135,7 @@ Jede Phase besteht aus nummerierten Meilensteinen (M0, M1, …). Innerhalb einer
 | 1 MVP   | M11-HOTFIX-006 | └─ SQLAdmin auf `/sqladmin/` umziehen (Issue #19, ADR-055) | [ERLEDIGT] 2026-05-03 |
 | 1 MVP   | M11-HOTFIX-007 | └─ MapLibre `GeolocateControl` in Karten-Komponenten (Issue #22) | [ERLEDIGT] 2026-05-03 |
 | 1 MVP   | M11-HOTFIX-008 | └─ Optionales `event.title`-Feld (Issue #27 Befund 4+5, ADR-056) | [ERLEDIGT] 2026-05-03 |
+| 1 MVP   | M11-HOTFIX-009 | └─ Application-Lifecycle Auto-Stop bei Event-Ende (Issue #23 Befund 2, ADR-057) | [ERLEDIGT] 2026-05-03 |
 | 2 Konso.| M12         | Self-Hosted Tileserver                           | [OFFEN]     |
 | 2 Konso.| M13         | Backup-Härtung & Restore-Tests                   | [OFFEN]     |
 | 2 Konso.| M14         | Monitoring & Alerting                            | [OFFEN]     |
@@ -2104,6 +2105,47 @@ Höchste Wahrscheinlichkeit: `BACKEND_INTERNAL_URL` ist im Frontend-Container ni
 - Verwandt: [#15](https://github.com/Paddel87/HC-Map/issues/15) (gleiche Wurzel-Hypothese), [ADR-053 §A/§C/§F](./decisions.md#adr-053--frontend-ssr-backend-adressierung-im-production-container-netz) (etabliertes Mechanismus, jetzt zusätzlich im Image gepinnt).
 - Operator-Kontext: Folge der Begehung auf Nodica1 mit `:rc` nach M11-HOTFIX-001-Pull; lokale Repro grün, Production-Verifikation steht aus.
 - Folge: HOTFIX-005 hat Hypothese 1 (SSR-Backend-URL) gehärtet, traf aber den eigentlichen Bug nicht — der ist Reverse-Proxy-Routing-Konflikt, gelöst in M11-HOTFIX-006.
+
+---
+
+### M11-HOTFIX-009 — Application-Lifecycle Auto-Stop bei Event-Ende (Issue #23 Befund 2, ADR-057)
+
+**Status:** `[ERLEDIGT]` 2026-05-03 — Owner-Freigabe von Patrick im RC-3-Triage-Block (Variante A); ADR-057 `Accepted`. Branch `claude/m11-hotfix-009-app-lifecycle-autostop` gestackt auf PR [#29](https://github.com/Paddel87/HC-Map/pull/29).
+
+**Problem:** Issue [#23](https://github.com/Paddel87/HC-Map/issues/23) Befund 2 (Operator-Feldtest, RC-3-Phase Nodica1) — drei zusammengehörige Beobachtungen:
+- 2a: Live-Event wird beendet, Applications bleiben offen-laufend → Lifecycle-Inkonsistenz.
+- 2b: Im laufenden Live-Event hat eine einzelne Application keinen sichtbaren Stop-Button — Workaround über „Event bearbeiten" mit manueller Eingabe.
+- 2c: Backend-Validatoren („Application endet nach Event-Ende") greifen korrekt, aber UX ist Sackgasse — User läuft erst beim Submit in den Konflikt.
+
+**Deliverables (alle erledigt):**
+- **ADR-057** (`Accepted`) in [`docs/decisions.md`](./decisions.md): Variante A (Backend Auto-Stop + Stop-Button + Pre-Submit-Hint), B/C verworfen, vier Out-of-Scope-Punkte (Auto-Restart, Multi-Active im Live-Modus, Audit-Log, Migrations-Daten-Reparatur).
+- **Backend-Helper** [`backend/app/services/events.py:auto_stop_open_applications`](../backend/app/services/events.py): UPDATE-by-event_id-Query, idempotent, Trigger setzt `updated_at` (RxDB-Cursor advanciert).
+- **Backend-Pfad 1 (POST `/api/events/{id}/end`):** [`end_event`](../backend/app/services/events.py) ruft Helper nach `flush()`. Direkter Trigger.
+- **Backend-Pfad 2 (PATCH `/api/events/{id}`):** [`update_event`](../backend/app/services/events.py) merkt sich `was_open = ended_at is None` vor dem Update, ruft Helper wenn `ended_at` von null auf non-null wechselt.
+- **Backend-Pfad 3 (RxDB-Push):** [`push_events`](../backend/app/sync/services.py) macht denselben `was_open`-Check innerhalb der `begin_nested()`-Savepoint-Transaktion. Lazy-Import von `auto_stop_open_applications` zur Vermeidung zirkulärer Module-Imports.
+- **Frontend-Stop-Button** in [`event-detail-view.tsx:ApplicationsTimeline`](../frontend/src/components/event/event-detail-view.tsx): pro aktive Application (`isLive && isActive`) ein `[data-testid="applications-timeline-stop"]`-Button mit `Square`-Icon, Klick ruft existierenden `handleEndApplication`-Handler. Komponente um Props `isLive` + `onStop` erweitert.
+- **Frontend Live-Validation** in [`event-edit-form.tsx`](../frontend/src/components/event/event-edit-form.tsx): `validateBackfill` läuft via `useMemo` auf jeden Form-State-Change. Errors werden auf `bounds`/`duration`/`overlap` gefiltert, bis der User submit drückt — ab dann sind alle Errors sichtbar (verhindert Noise auf First-Paint). Submit-Pfad nutzt dieselben `liveErrors` als Block-Bedingung statt Re-Validation.
+
+**Verifikation:**
+- Zwei neue pytest-Tests in [`backend/tests/test_events_live_api.py`](../backend/tests/test_events_live_api.py):
+  - `test_end_event_auto_stops_running_applications`: Event → 2 Applications, eine manuell beendet vor Event-Ende, andere läuft → Event-Ende, beide haben `ended_at`, Auto-gestoppte hat exakt `event.ended_at`-Timestamp.
+  - `test_patch_event_with_ended_at_auto_stops_applications`: PATCH-Pfad-Variante.
+- `uv run pytest -q` → **258/258 grün** (256 + 2 neue).
+- `uv run ruff check app tests` → All checks passed.
+- `uv run ruff format` (auto-applied auf services.py + test): clean nach Re-Format.
+- `pnpm typecheck` → clean.
+- `pnpm lint` → clean.
+- `pnpm test` → **282/282 grün**.
+- `pnpm prettier --check` (per-file) → clean.
+- **Browser-Verifikation** (Dev-Stack lokal hochgefahren via `preview_*`, Alembic-Migration aus M11-HOTFIX-008 angewandt):
+  - End-to-End API-Smoke: Event-Start mit Title → 2 Applications gestartet → Event beendet → beide Applications haben `ended_at` exakt = `event.ended_at` (Auto-Stop greift).
+  - Frontend Stop-Button: Event-Detail-View zeigt `[data-testid="applications-timeline-stop"]`-Button für aktive Application; Klick → Status wechselt von „läuft" zu „beendet", Button verschwindet (kein zweiter Stop möglich).
+
+**Bezug:**
+- Issue: [#23 — Operator-Befundbericht I Befund 2](https://github.com/Paddel87/HC-Map/issues/23) (Application-Lifecycle).
+- ADR: [ADR-057 — Application-Lifecycle Auto-Stop](./decisions.md) (Status `Accepted`).
+- Vorgänger: ADR-011 (Live-Modus Lifecycle), ADR-029 (FWW vs LWW), ADR-038 (Detail-View), ADR-039/040 (Backfill-/Edit-Validation).
+- Folge: Operator-Verifikation auf Nodica1 nach Stack-Merge (idealerweise live-Event mit zwei parallelen Applications anlegen, Event beenden, prüfen dass beide auf ended_at gesetzt sind).
 
 ---
 

--- a/frontend/src/components/event/event-detail-view.tsx
+++ b/frontend/src/components/event/event-detail-view.tsx
@@ -16,7 +16,7 @@
  *      defense-in-depth step described in ADR-036 §B.
  */
 
-import { Flag, Pause, Pencil, Play, Plus } from "lucide-react";
+import { Flag, Pause, Pencil, Play, Plus, Square } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
@@ -188,7 +188,12 @@ export function EventDetailView({ user, initialEvent }: EventDetailViewProps) {
                 : "In diesem Event wurden keine Applications erfasst."}
             </p>
           ) : (
-            <ApplicationsTimeline applications={applications} now={now} />
+            <ApplicationsTimeline
+              applications={applications}
+              now={now}
+              isLive={isLive}
+              onStop={isLive ? handleEndApplication : undefined}
+            />
           )}
         </CardContent>
       </Card>
@@ -292,9 +297,13 @@ function useApplications(eventId: string): ApplicationDocType[] {
 function ApplicationsTimeline({
   applications,
   now,
+  isLive,
+  onStop,
 }: {
   applications: ApplicationDocType[];
   now: number;
+  isLive: boolean;
+  onStop?: (applicationId: string) => Promise<void> | void;
 }) {
   // M7.5: resolve restraint_type_ids → display names via the M7.x
   // catalog cache. Same query key the picker uses, so this view shares
@@ -402,7 +411,21 @@ function ApplicationsTimeline({
                 </p>
               ) : null}
             </div>
-            <span className="font-mono text-base tabular-nums">{formatDuration(seconds)}</span>
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-base tabular-nums">{formatDuration(seconds)}</span>
+              {isLive && isActive && onStop ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => void onStop(application.id)}
+                  data-testid="applications-timeline-stop"
+                  aria-label={`Application #${application.sequence_no} beenden`}
+                >
+                  <Square aria-hidden /> Stop
+                </Button>
+              ) : null}
+            </div>
           </li>
         );
       })}

--- a/frontend/src/components/event/event-edit-form.tsx
+++ b/frontend/src/components/event/event-edit-form.tsx
@@ -100,7 +100,31 @@ export function EventEditForm({ user, initialEvent }: EventEditFormProps) {
   const [applications, setApplications] = useState<EditableApplication[]>([]);
   const [loading, setLoading] = useState(true);
   const [pending, setPending] = useState(false);
-  const [errors, setErrors] = useState<BackfillError[]>([]);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+
+  // ADR-057 §E: re-run validateBackfill on every form-state change so
+  // bounds/duration violations surface inline instead of waiting for
+  // the user to hit submit. Errors are only rendered after the first
+  // submit attempt to avoid noisy first-paint complaints about empty
+  // fields the user hasn't touched yet.
+  const liveErrors = useMemo<BackfillError[]>(() => {
+    if (!event) return [];
+    const result = validateBackfill({
+      lat: typeof initialEvent.lat === "number" ? initialEvent.lat : Number(initialEvent.lat),
+      lon: typeof initialEvent.lon === "number" ? initialEvent.lon : Number(initialEvent.lon),
+      startedAt: initialEvent.started_at,
+      endedAt: localToIso(event.endedAt),
+      applications: applications.map((a) => ({
+        uiId: a.id,
+        startedAt: localToIso(a.startedAt),
+        endedAt: localToIso(a.endedAt),
+        recipientId: a.recipientId || null,
+        note: a.note || null,
+      })),
+    });
+    return result.valid ? [] : result.errors;
+  }, [event, applications, initialEvent]);
+  const errors = submitAttempted ? liveErrors : liveErrors.filter(isBoundsOrDuration);
 
   // Load event + applications from RxDB once (ADR-040 §F).
   useEffect(() => {
@@ -200,31 +224,15 @@ export function EventEditForm({ user, initialEvent }: EventEditFormProps) {
 
   async function handleSubmit(formEvent: React.FormEvent<HTMLFormElement>) {
     formEvent.preventDefault();
+    setSubmitAttempted(true);
     if (!database || !event || !eventInitial) return;
 
-    // Validate via the M5c.3 helper — started_at values are immutable
-    // here, so we hand them through unchanged (ADR-040 §G).
-    const validation = validateBackfill({
-      lat: typeof initialEvent.lat === "number" ? initialEvent.lat : Number(initialEvent.lat),
-      lon: typeof initialEvent.lon === "number" ? initialEvent.lon : Number(initialEvent.lon),
-      startedAt: initialEvent.started_at,
-      endedAt: localToIso(event.endedAt),
-      applications: applications.map((a) => ({
-        uiId: a.id,
-        startedAt: localToIso(a.startedAt),
-        endedAt: localToIso(a.endedAt),
-        recipientId: a.recipientId || null,
-        note: a.note || null,
-      })),
-    });
-    if (!validation.valid) {
-      setErrors(validation.errors);
-      toast.error(`${validation.errors.length} Eingabe-Probleme`, {
+    if (liveErrors.length > 0) {
+      toast.error(`${liveErrors.length} Eingabe-Probleme`, {
         description: "Bitte die markierten Felder prüfen.",
       });
       return;
     }
-    setErrors([]);
 
     setPending(true);
     try {
@@ -584,4 +592,9 @@ function setEquals(a: readonly string[], b: readonly string[]): boolean {
     if (!set.has(item)) return false;
   }
   return true;
+}
+
+function isBoundsOrDuration(err: BackfillError): boolean {
+  if (err.kind === "event") return err.field === "duration";
+  return err.field === "bounds" || err.field === "duration" || err.field === "overlap";
 }


### PR DESCRIPTION
Re-opens [#30](https://github.com/Paddel87/HC-Map/pull/30) — durch Stack-Merge auto-geschlossen, Branch jetzt sauber auf `main` rebased.

## Summary

- Backend: neuer `auto_stop_open_applications`-Helper, eingebunden in `end_event`, `update_event` und `_apply_event_update` (Sync).
- Frontend: Stop-Button pro aktive Application in der Event-Detail-Timeline + Live-Validation im Edit-Form.
- ADR-057 (`Accepted`).

Closes [#23](https://github.com/Paddel87/HC-Map/issues/23) Befund 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)