### PR TITLE
feat(m11-hotfix-011): reveal_participants-Toggle im Beteiligte-Tab (Issue #23, ADR-059)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Bis zum ersten Go-Live (M11) bleibt das Projekt auf `0.0.0`.
 
 ## [Unreleased]
 
+### Changed
+
+- **M11-HOTFIX-011 — `reveal_participants`-Toggle prominent im Beteiligte-Tab (2026-05-03, Issue [#23](https://github.com/Paddel87/HC-Map/issues/23) Befund 1 / korrigiert via [#27](https://github.com/Paddel87/HC-Map/issues/27), ADR-059).**
+  Der Sichtbarkeits-Toggle für Klarnamen, der bisher nur im Edit-UI versteckt war, erscheint jetzt direkt im Beteiligte-Card-Header der Event-Detail-Ansicht — sichtbar nur für Editoren (Admin oder Event-Ersteller). Strikte Default-Logik („Klardaten verborgen, sichtbar nur via expliziter Aktion") bleibt unverändert; die Aktion ist über den RxDB-`updated_at`-Cursor und den M11-HOTFIX-003-Logger protokolliert. Der bestehende Edit-UI-Toggle bleibt zusätzlich verfügbar. Frontend-only, kein Backend-Touch. **Damit ist der RC-3-Operator-Befundbericht-Triage-Block ([#22](https://github.com/Paddel87/HC-Map/issues/22)–[#27](https://github.com/Paddel87/HC-Map/issues/27)) vollständig abgearbeitet.**
+
 ### Added
 
 - **M11-HOTFIX-010 — Event.`time_precision`-Marker für retrospektive Erfassung (2026-05-03, Issue [#24](https://github.com/Paddel87/HC-Map/issues/24), ADR-058).**

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5357,4 +5357,67 @@ Application-Zeiten werden weiter mit voller `toLocaleString`-Formatierung angeze
 
 ---
 
+## ADR-059 — `reveal_participants`-Toggle im Beteiligte-Tab statt versteckt im Edit-UI (Issue #23 Befund 1, korrigiert via #27)
+
+**Status:** Accepted
+**Datum:** 2026-05-03
+**Freigabe:** 2026-05-03 (Patrick — Variante A, Reihenfolge-Freigabe nach Operator-Befundbericht-Triage)
+**Kategorie:** §5 (UX-Platzierung, Frontend-only) — formal autonom, aber als ADR dokumentiert wegen Privacy-Architektur-Bezug.
+**Vorgänger:** [ADR-038](./decisions.md) (Detail-View Maskierung), [ADR-040](./decisions.md) (Edit-UI mit `reveal_participants`-Checkbox).
+
+### Kontext
+
+Issue [#23](https://github.com/Paddel87/HC-Map/issues/23) Befund 1 (Operator-Feldtest, RC-3-Phase Nodica1) wurde im Folgebericht [#27](https://github.com/Paddel87/HC-Map/issues/27) **korrigiert**: ursprünglich vermutet als „Privacy by Default zu streng — Operator sieht eigene Beteiligte nicht", in [#27](https://github.com/Paddel87/HC-Map/issues/27) entdeckte Patrick selbst, dass im Edit-UI ein `reveal_participants`-Toggle existiert. Die strikte Default-Logik („Klardaten sichtbar nur via expliziter, audit-fähiger Aktion") ist DSGVO-konform und bleibt korrekt.
+
+**Eigentlicher UX-Defekt (nach Korrektur):** der Toggle ist im Edit-UI versteckt — selbst der Event-Ersteller findet ihn nur durch Zufall. Operator-Folgerung: „der Sichtbarkeits-Toggle ist im Bearbeiten-Modus versteckt und nicht auffindbar".
+
+### Entscheidungen
+
+**A. Toggle prominent im Beteiligte-Tab platzieren (Variante A aus dem Triage-Block).**
+
+Drei Alternativen wurden Patrick vorgelegt:
+- **A — Toggle im Beteiligte-Tab** (dort wo `[verborgen]` steht), mit Erklärungstext „Aktiviert die Anzeige der Klardaten für dich. Diese Aktion wird protokolliert."
+- **B — Eigener „Sichtbarkeit / Berechtigungen"-Block** im Event-Detail. Verworfen: überstrukturiert solange es nur ein Flag ist; mehr UI-Fläche, kein klarer Mehrwert.
+- **C — Status quo + Tooltip am `[verborgen]`-Marker.** Verworfen: löst nicht das Problem (Toggle bleibt im Edit-UI versteckt), nur die Frustration.
+
+**Patrick wählt A.** Begründung: Toggle gehört semantisch dort hin, wo der versteckte Inhalt sichtbar wird.
+
+**B. Sichtbarkeit nur für Editoren.**
+
+Der Toggle erscheint nur, wenn `canEditEvent(user, { created_by: event.created_by })` → true (Admin oder Event-Ersteller). Andere User sehen wie bisher die Beteiligten-Liste mit Maskierung, ohne Toggle. Das verhindert versehentliche Sichtbarkeits-Änderungen durch nicht-berechtigte Beteiligte.
+
+**C. Implementation: bestehender RxDB-Patch-Pfad.**
+
+Der Toggle ruft denselben `database.events.findOne(id).patch({ reveal_participants: ..., updated_at: ... })`-Pfad, der vom Edit-UI bereits genutzt wird. Sync nach Backend läuft über RxDB-Replication (LWW per ADR-029). Der bestehende Edit-UI-Toggle bleibt unverändert — der neue Detail-View-Toggle ist eine zusätzliche Eintrittstür, kein Ersatz.
+
+**D. UI-Form.**
+
+Im Beteiligte-Card-Header (vor der Liste): kompakter Switch/Checkbox mit Label „Klarnamen sichtbar" plus Hint-Text „Audit-pflichtige Aktion — wird protokolliert" (kursiv, klein). Live-Update der Maskierungs-Logik über die existierende RxDB-Subscription (ADR-038 §C).
+
+**E. Out-of-Scope (nicht Teil dieses ADR).**
+
+- **Audit-Log für Toggle-Klick:** kein Audit-Log-System im Repo. Die Erklärungstext-Aussage „wird protokolliert" verweist auf den `updated_at`-Cursor, der die Änderung in RxDB-Sync-Logs sichtbar macht (M11-HOTFIX-003 Logger). Echtes Audit-Log = M14/M16-Folge-ADR.
+- **Pro-Person-Sichtbarkeit:** weiterhin alles-oder-nichts (Event-Flag), keine Einzel-Person-Berechtigung.
+- **Server-Side-RBAC für reveal_participants:** Backend-Validierung wird in ADR-040 §C bereits durchgesetzt (Patch-Route gibt 403 für Nicht-Editoren); Frontend-Toggle macht das sichtbar, aber Backend bleibt die Source of Truth.
+
+### Verworfene Alternativen
+
+- **Variante B (Eigener Sichtbarkeits-Block).** Überstrukturiert für ein einzelnes Flag; mehr UI-Fläche, kein klarer Mehrwert.
+- **Variante C (Tooltip ohne Toggle).** Löst nicht das eigentliche Problem (Toggle bleibt schwer erreichbar).
+- **Toggle für alle User sichtbar.** Verworfen: nicht-berechtigte Beteiligte könnten versehentlich klicken; auch wenn Backend 403 gibt, ist das verwirrend.
+
+### Folgearbeit
+
+- **M11-HOTFIX-011** (Fahrplan-Eintrag): Implementierung dieser ADR.
+- **#23 Befund 1 schließen** nach Operator-Verifikation auf Production (Toggle erscheint im Beteiligte-Tab, Klick schaltet Klarnamen frei, andere Beteiligte sehen den Toggle nicht).
+
+### Referenzen
+
+- [Issue #23 — Operator-Befundbericht I Befund 1](https://github.com/Paddel87/HC-Map/issues/23) und [Issue #27 — Korrektur zu Befund 1](https://github.com/Paddel87/HC-Map/issues/27)
+- [ADR-038 — Maskierung im Detail-View](./decisions.md)
+- [ADR-040 — Edit-UI mit `reveal_participants`-Checkbox](./decisions.md)
+- Code-Stellen: [`frontend/src/components/event/event-detail-view.tsx`](../frontend/src/components/event/event-detail-view.tsx), [`frontend/src/lib/rbac.ts`](../frontend/src/lib/rbac.ts) (canEditEvent)
+
+---
+
 **Hinweis zur Initialisierungs-Entscheidung:** Die initiale Anpassung der Vorlagen-Dokumente an HC-Map-Komplexität ist in **ADR-009 (Vorgehensmodell: Vision-driven Scoping vor Code)** dokumentiert. Diese ADR übernimmt die Funktion, die in der generischen Vorlage für ADR-001 vorgesehen war.

--- a/docs/fahrplan.md
+++ b/docs/fahrplan.md
@@ -137,6 +137,7 @@ Jede Phase besteht aus nummerierten Meilensteinen (M0, M1, …). Innerhalb einer
 | 1 MVP   | M11-HOTFIX-008 | └─ Optionales `event.title`-Feld (Issue #27 Befund 4+5, ADR-056) | [ERLEDIGT] 2026-05-03 |
 | 1 MVP   | M11-HOTFIX-009 | └─ Application-Lifecycle Auto-Stop bei Event-Ende (Issue #23 Befund 2, ADR-057) | [ERLEDIGT] 2026-05-03 |
 | 1 MVP   | M11-HOTFIX-010 | └─ Event.`time_precision`-Marker für retrospektive Erfassung (Issue #24, ADR-058) | [ERLEDIGT] 2026-05-03 |
+| 1 MVP   | M11-HOTFIX-011 | └─ `reveal_participants`-Toggle prominent im Beteiligte-Tab (Issue #23 Befund 1, ADR-059) | [ERLEDIGT] 2026-05-03 |
 | 2 Konso.| M12         | Self-Hosted Tileserver                           | [OFFEN]     |
 | 2 Konso.| M13         | Backup-Härtung & Restore-Tests                   | [OFFEN]     |
 | 2 Konso.| M14         | Monitoring & Alerting                            | [OFFEN]     |
@@ -2106,6 +2107,38 @@ Höchste Wahrscheinlichkeit: `BACKEND_INTERNAL_URL` ist im Frontend-Container ni
 - Verwandt: [#15](https://github.com/Paddel87/HC-Map/issues/15) (gleiche Wurzel-Hypothese), [ADR-053 §A/§C/§F](./decisions.md#adr-053--frontend-ssr-backend-adressierung-im-production-container-netz) (etabliertes Mechanismus, jetzt zusätzlich im Image gepinnt).
 - Operator-Kontext: Folge der Begehung auf Nodica1 mit `:rc` nach M11-HOTFIX-001-Pull; lokale Repro grün, Production-Verifikation steht aus.
 - Folge: HOTFIX-005 hat Hypothese 1 (SSR-Backend-URL) gehärtet, traf aber den eigentlichen Bug nicht — der ist Reverse-Proxy-Routing-Konflikt, gelöst in M11-HOTFIX-006.
+
+---
+
+### M11-HOTFIX-011 — `reveal_participants`-Toggle prominent im Beteiligte-Tab (Issue #23 Befund 1, ADR-059)
+
+**Status:** `[ERLEDIGT]` 2026-05-03 — Owner-Freigabe von Patrick im RC-3-Triage-Block (Variante A, niedrige Prio); ADR-059 `Accepted`. Branch `claude/m11-hotfix-011-reveal-toggle` gestackt auf PR [#31](https://github.com/Paddel87/HC-Map/pull/31).
+
+**Problem:** Issue [#23](https://github.com/Paddel87/HC-Map/issues/23) Befund 1, korrigiert via [#27](https://github.com/Paddel87/HC-Map/issues/27): der `reveal_participants`-Toggle existiert bereits im Edit-UI (ADR-040), ist dort aber so versteckt, dass selbst der Event-Ersteller ihn nur durch Zufall findet. Strikte Default-Logik („Klardaten sichtbar nur via expliziter, audit-fähiger Aktion") ist DSGVO-konform und bleibt korrekt — nur die Auffindbarkeit ist das Problem.
+
+**Deliverables (alle erledigt):**
+- **ADR-059** (`Accepted`) in [`docs/decisions.md`](./decisions.md): Variante A (Toggle prominent im Beteiligte-Tab), B (eigener Berechtigungs-Block) und C (nur Tooltip) verworfen, drei Out-of-Scope-Punkte (Audit-Log-System, Pro-Person-Sichtbarkeit, Server-Side-RBAC bleibt in ADR-040).
+- **Frontend `RevealParticipantsToggle`-Komponente** in [`event-detail-view.tsx`](../frontend/src/components/event/event-detail-view.tsx): Card-Header-Element im Beteiligte-Block, kompakte Checkbox + Erklärungstext „Audit-pflichtige Aktion — wird protokolliert". Sichtbar nur wenn `canEditEvent(user, ...)` → true (Admin oder Event-Ersteller).
+- **`handleToggleReveal`-Handler:** RxDB-Patch auf `events`-Collection (`reveal_participants`, `updated_at`) — identischer Pfad wie das bestehende Edit-UI, kein neuer Backend-Endpoint. Toast-Bestätigung mit Verweis auf Audit-Trail über RxDB-Sync (M11-HOTFIX-003 Logger).
+- **Edit-UI-Toggle bleibt unverändert** — der neue Detail-View-Toggle ist eine zusätzliche Eintrittstür, kein Ersatz.
+
+**Verifikation:**
+- `pnpm typecheck` → clean.
+- `pnpm lint` → clean.
+- `pnpm test` → **282/282 grün** (kein Test-Helper-Update nötig — bestehende Tests decken die Maskierungs-Logik bereits ab).
+- `pnpm prettier --check` (per-file) → clean nach auto-format.
+- **Browser-Verifikation** (Dev-Stack lokal hochgefahren via `preview_*`, eingeloggt als Admin):
+  - `/events/{id}` zeigt `[data-testid="reveal-participants-toggle"]` im Beteiligte-Card-Header mit Label „Klarnamen sichtbar" und Erklärungstext „Audit-pflichtige Aktion — wird protokolliert (ADR-059)".
+  - Initial-Wert `unchecked` (Default `reveal_participants=false`).
+  - Klick auf Checkbox → `checked=true`, RxDB-Push läuft, GET `/api/events/{id}` zeigt `reveal_participants: true` (End-to-End-Sync bestätigt).
+
+**Bezug:**
+- Issue: [#23 Befund 1](https://github.com/Paddel87/HC-Map/issues/23) + [#27 Korrektur](https://github.com/Paddel87/HC-Map/issues/27).
+- ADR: [ADR-059 — `reveal_participants`-Toggle im Beteiligte-Tab](./decisions.md) (Status `Accepted`).
+- Vorgänger: ADR-038 (Maskierung), ADR-040 (Edit-UI mit Original-Checkbox).
+- Folge: Operator-Verifikation auf Nodica1 nach Stack-Merge — Toggle erscheint im Beteiligte-Tab, Klick schaltet Klarnamen frei, andere Beteiligte sehen den Toggle nicht.
+
+**Damit ist der RC-3-Operator-Befundbericht-Triage-Block (Issues #22–#27) komplett abgearbeitet** — fünf Hotfixes (007–011), fünf neue ADRs (056–059, plus M11-HOTFIX-007 ohne ADR), alle gestackt als PR-Kette #28 → #29 → #30 → #31 → #32.
 
 ---
 

--- a/frontend/src/components/event/event-detail-view.tsx
+++ b/frontend/src/components/event/event-detail-view.tsx
@@ -93,6 +93,20 @@ export function EventDetailView({ user, initialEvent }: EventDetailViewProps) {
     await doc.patch({ ended_at: now, updated_at: now });
   }
 
+  async function handleToggleReveal(next: boolean): Promise<void> {
+    if (!database) return;
+    const doc = await database.events.findOne(initialEvent.id).exec();
+    if (!doc) {
+      toast.error("Event nicht im lokalen Speicher gefunden");
+      return;
+    }
+    const now = new Date().toISOString();
+    await doc.patch({ reveal_participants: next, updated_at: now });
+    toast.success(next ? "Klarnamen für dich freigegeben" : "Klarnamen wieder verborgen", {
+      description: "Audit-pflichtige Aktion — wird über RxDB-Sync protokolliert.",
+    });
+  }
+
   async function handleEndEvent(): Promise<void> {
     if (!database) return;
     const doc = await database.events.findOne(initialEvent.id).exec();
@@ -213,6 +227,12 @@ export function EventDetailView({ user, initialEvent }: EventDetailViewProps) {
                 ? `${maskedParticipants.length} Beteiligte sichtbar.`
                 : "Andere Beteiligte werden verborgen."}
           </CardDescription>
+          {editable ? (
+            <RevealParticipantsToggle
+              checked={event.reveal_participants}
+              onChange={handleToggleReveal}
+            />
+          ) : null}
         </CardHeader>
         <CardContent>
           <ParticipantsList participants={maskedParticipants} currentPersonId={user.person_id} />
@@ -437,6 +457,34 @@ function ApplicationsTimeline({
         );
       })}
     </ul>
+  );
+}
+
+function RevealParticipantsToggle({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (next: boolean) => Promise<void> | void;
+}) {
+  return (
+    <label
+      className="mt-2 flex flex-col gap-1 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-800 dark:bg-slate-900/40"
+      data-testid="reveal-participants-toggle"
+    >
+      <span className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(event) => void onChange(event.target.checked)}
+          data-testid="reveal-participants-checkbox"
+        />
+        <span className="font-medium">Klarnamen sichtbar</span>
+      </span>
+      <span className="text-xs italic text-slate-600 dark:text-slate-400">
+        Audit-pflichtige Aktion — wird protokolliert (ADR-059).
+      </span>
+    </label>
   );
 }
 


### PR DESCRIPTION
Re-opens [#32](https://github.com/Paddel87/HC-Map/pull/32) — durch Stack-Merge auto-geschlossen, Branch jetzt sauber auf `main` rebased.

## Summary

- Neue `RevealParticipantsToggle`-Komponente im Beteiligte-Card-Header der Event-Detail-Ansicht.
- Sichtbar nur für Editoren, Klick patcht via RxDB-Push (kein neuer Backend-Endpoint).
- ADR-059 (`Accepted`).

Closes [#23](https://github.com/Paddel87/HC-Map/issues/23) Befund 1 (korrigiert via [#27](https://github.com/Paddel87/HC-Map/issues/27)).

**Damit ist der RC-3-Operator-Befundbericht-Triage-Block ([#22](https://github.com/Paddel87/HC-Map/issues/22)–[#27](https://github.com/Paddel87/HC-Map/issues/27)) vollständig in `main`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)